### PR TITLE
Implement CKEditor Custom Configuration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,7 @@
         "drupal/admin_toolbar": "^1.26",
         "drupal/allowed_formats": "^1.1",
         "drupal/block_type_templates": "^1.0@alpha",
+        "drupal/ckeditor_config": "^2.0@RC",
         "drupal/config_ignore": "^2.1",
         "drupal/config_split": "^1.4",
         "drupal/console": "^1.0.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4d01760b0dc3fd6ff28c9923545b0cc9",
+    "content-hash": "942e187ab1181ceee86ab141098e2644",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -2323,6 +2323,60 @@
             "homepage": "https://www.drupal.org/project/block_type_templates",
             "support": {
                 "source": "http://cgit.drupalcode.org/block_type_templates"
+            }
+        },
+        {
+            "name": "drupal/ckeditor_config",
+            "version": "2.0.0-rc1",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/ckeditor_config.git",
+                "reference": "8.x-2.0-rc1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/ckeditor_config-8.x-2.0-rc1.zip",
+                "reference": "8.x-2.0-rc1",
+                "shasum": "ad3368a2157760eb9759de33ad1980ba9c487038"
+            },
+            "require": {
+                "drupal/core": "^8.5"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "branch-alias": {
+                    "dev-2.x": "2.x-dev"
+                },
+                "drupal": {
+                    "version": "8.x-2.0-rc1",
+                    "datestamp": "1556038981",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "Project has not opted into security advisory coverage!"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "authors": [
+                {
+                    "name": "Chris Burge",
+                    "homepage": "https://www.drupal.org/u/chris-burge",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Martin Klíma (martin_klima)",
+                    "homepage": "https://www.drupal.org/u/martin_klima",
+                    "role": "Maintainer"
+                }
+            ],
+            "description": "Extends core CKEditor to support custom configuration.",
+            "homepage": "https://www.drupal.org/project/ckeditor_config",
+            "support": {
+                "source": "https://git.drupalcode.org/project/ckeditor_config",
+                "issues": "https://www.drupal.org/project/issues/ckeditor_config"
             }
         },
         {
@@ -10180,6 +10234,7 @@
     "minimum-stability": "dev",
     "stability-flags": {
         "drupal/block_type_templates": 15,
+        "drupal/ckeditor_config": 5,
         "drupal/diff": 5,
         "unlcms/unl_cas": 20,
         "unlcms/unl_five": 20

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -8,6 +8,7 @@ module:
   block_type_templates: 0
   breakpoint: 0
   ckeditor: 0
+  ckeditor_config: 0
   config: 0
   config_filter: 0
   config_ignore: 0

--- a/config/sync/editor.editor.standard.yml
+++ b/config/sync/editor.editor.standard.yml
@@ -46,6 +46,8 @@ settings:
       styles: ''
     language:
       language_list: un
+    customconfig:
+      ckeditor_custom_config: 'forcePasteAsPlainText = true'
 image_upload:
   status: false
   scheme: public


### PR DESCRIPTION
This project will need to implement custom CKEditor configuration on an editor-by-editor basis. This how _paste plain text_ will be enforced.

Proposed module: https://www.drupal.org/project/ckeditor_config.

The module currently applies custom config globally; however, I have proposed a rewrite to support config on an editor-by-editor basis. I've also offered to maintain or co-maintain, as the module is inactive and has no releases.

Relevant issues:
[Offering to maintain or co-maintain ckeditor_config](https://www.drupal.org/project/ckeditor_config/issues/3049008)
[Attach Custom Configuration to Individual Editors](https://www.drupal.org/project/ckeditor_config/issues/3049020)
