### PR TITLE
Change composer.json to use 'develop' branch of 'unl/wdntemplates'

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
                 "source": {
                     "type": "git",
                     "url": "https://github.com/unl/wdntemplates.git",
-                    "reference": "5.0"
+                    "reference": "develop"
                 }
             }
         }
@@ -53,6 +53,7 @@
         "drupal/pathauto": "^1.3",
         "drupal/token": "^1.5",
         "drush/drush": "^9.0.0",
+        "unl/wdntemplates": "^5.0",
         "unlcms/project-herbie-composer-plugin": "^1.0",
         "unlcms/unl_cas": "dev-8.x-1.x",
         "unlcms/unl_five": "dev-8.x-5.0.x",
@@ -62,7 +63,6 @@
         "zaporylie/composer-drupal-optimizations": "^1.0"
     },
     "require-dev": {
-        "unl/wdntemplates": "^5.0",
         "webflo/drupal-core-require-dev": "^8.6.0"
     },
     "conflict": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4d01760b0dc3fd6ff28c9923545b0cc9",
+    "content-hash": "0a714fe8bc5d26ff9824944c008138f5",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -7357,6 +7357,16 @@
             "time": "2019-03-01T17:43:52+00:00"
         },
         {
+            "name": "unl/wdntemplates",
+            "version": "5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/unl/wdntemplates.git",
+                "reference": "develop"
+            },
+            "type": "library"
+        },
+        {
             "name": "unlcms/project-herbie-composer-plugin",
             "version": "1.0.0",
             "source": {
@@ -10126,16 +10136,6 @@
             ],
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
             "time": "2019-04-04T09:56:43+00:00"
-        },
-        {
-            "name": "unl/wdntemplates",
-            "version": "5.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/unl/wdntemplates.git",
-                "reference": "5.0"
-            },
-            "type": "library"
         },
         {
             "name": "webflo/drupal-core-require-dev",


### PR DESCRIPTION
composer.json pulls down the '5.0' branch of 'unl/wdntemplates'. Development is taking place on the 'develop' branch. This issue seeks to switch to the 'develop' branch.