### PR TITLE
Define Roles

### DIFF
--- a/config/sync/system.action.user_add_role_action.editor.yml
+++ b/config/sync/system.action.user_add_role_action.editor.yml
@@ -1,0 +1,14 @@
+uuid: f93b520f-c417-4eec-8b72-727a83a9b5a3
+langcode: en
+status: true
+dependencies:
+  config:
+    - user.role.editor
+  module:
+    - user
+id: user_add_role_action.editor
+label: 'Add the Editor role to the selected user(s)'
+type: user
+plugin: user_add_role_action
+configuration:
+  rid: editor

--- a/config/sync/system.action.user_remove_role_action.editor.yml
+++ b/config/sync/system.action.user_remove_role_action.editor.yml
@@ -1,0 +1,14 @@
+uuid: cd730acd-ef14-46d1-91ea-5b8c1778bee0
+langcode: en
+status: true
+dependencies:
+  config:
+    - user.role.editor
+  module:
+    - user
+id: user_remove_role_action.editor
+label: 'Remove the Editor role from the selected user(s)'
+type: user
+plugin: user_remove_role_action
+configuration:
+  rid: editor

--- a/config/sync/user.role.administrator.yml
+++ b/config/sync/user.role.administrator.yml
@@ -4,7 +4,7 @@ status: true
 dependencies: {  }
 id: administrator
 label: Administrator
-weight: 2
+weight: -7
 is_admin: null
 permissions:
   - 'access administration pages'

--- a/config/sync/user.role.anonymous.yml
+++ b/config/sync/user.role.anonymous.yml
@@ -6,7 +6,7 @@ _core:
   default_config_hash: j5zLMOdJBqC0bMvSdth5UebkprJB8g_2FXHqhfpJzow
 id: anonymous
 label: 'Anonymous user'
-weight: 0
+weight: -10
 is_admin: false
 permissions:
   - 'access content'

--- a/config/sync/user.role.authenticated.yml
+++ b/config/sync/user.role.authenticated.yml
@@ -6,9 +6,10 @@ _core:
   default_config_hash: dJ0L2DNSj5q6XVZAGsuVDpJTh5UeYkIPwKrUOOpr8YI
 id: authenticated
 label: 'Authenticated user'
-weight: 1
+weight: -9
 is_admin: false
 permissions:
   - 'access content'
+  - 'access contextual links'
   - 'use text format standard'
   - 'view media'

--- a/config/sync/user.role.editor.yml
+++ b/config/sync/user.role.editor.yml
@@ -1,0 +1,23 @@
+uuid: 9785a012-13f3-431d-9439-f7d19859f9ec
+langcode: en
+status: true
+dependencies: {  }
+id: editor
+label: Editor
+weight: -8
+is_admin: null
+permissions:
+  - 'access administration pages'
+  - 'access content overview'
+  - 'access media overview'
+  - 'access toolbar'
+  - 'configure editable builder_page node layout overrides'
+  - 'create builder_page content'
+  - 'create url aliases'
+  - 'delete any builder_page content'
+  - 'delete builder_page revisions'
+  - 'edit any builder_page content'
+  - 'revert builder_page revisions'
+  - 'view builder_page revisions'
+  - 'view own unpublished content'
+  - 'view the administration theme'


### PR DESCRIPTION
Previously in Drupal 7 most people were given the wide ranging Site Admin role.

- Site Admin: has the highest level of access; can add/edit/delete all content, as well as manage things like menus, modules, config, and user accounts.
- Content Admin: can add/edit/delete all content, but not able to manage user accounts nor site configuration.

(Proposal) For this project:

- Editor: Standard role for everyone that gives content editing access.
- Site Customizer: For web developers in the circle of trust. allows custom content type creation, etc, but also means the site is now marked as a "Custom Site"
- Coder: A slim role that just allows someone to create/edit the HTML code Custom Block

