### PR TITLE
Patch Views to allow @ in class names

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -121,6 +121,9 @@
             },
             "drupal/config_ignore": {
                 "2857247 - Support for export filtering via Drush": "https://www.drupal.org/files/issues/2018-04-19/support-for-export-2857247-18.patch"
+            },
+            "drupal/core": {
+                "Custom - Allow '@' in CSS selectors for Views displays": "patches/custom-views-DisplayPluginBase-valid-css-selector.patch"
             }
         },
         "drupal-scaffold": {

--- a/patches/custom-views-DisplayPluginBase-valid-css-selector.patch
+++ b/patches/custom-views-DisplayPluginBase-valid-css-selector.patch
@@ -1,0 +1,15 @@
+Drupal\views\Plugin\views\display\DisplayPluginBase::validateOptionsForm rejects valid CSS selectors, including '@', which is valid if escaped in CSS.
+
+diff --git a/core/modules/views/src/Plugin/views/display/DisplayPluginBase.php b/core/modules/views/src/Plugin/views/display/DisplayPluginBase.php
+index 4fe9d1e204..09dbec1945 100644
+--- a/core/modules/views/src/Plugin/views/display/DisplayPluginBase.php
++++ b/core/modules/views/src/Plugin/views/display/DisplayPluginBase.php
+@@ -1861,7 +1861,7 @@ public function validateOptionsForm(&$form, FormStateInterface $form_state) {
+         break;
+       case 'css_class':
+         $css_class = $form_state->getValue('css_class');
+-        if (preg_match('/[^a-zA-Z0-9-_ ]/', $css_class)) {
++        if (preg_match('/[^a-zA-Z0-9-_@ ]/', $css_class)) {
+           $form_state->setError($form['css_class'], $this->t('CSS classes must be alphanumeric or dashes only.'));
+         }
+         break;


### PR DESCRIPTION
Adding a CSS class of "dcf-grid-halves@md" to a view gives:

`CSS classes must be alphanumeric or dashes only.`

Adding @ won't hurt anything in /web/core/modules/views/src/Plugin/views/display/DisplayPluginBase.php

```
  public function validateOptionsForm(&$form, FormStateInterface $form_state) {
    $section = $form_state->get('section');
    switch ($section) {
      case 'display_title':
        if ($form_state->isValueEmpty('display_title')) {
          $form_state->setError($form['display_title'], $this->t('Display title may not be empty.'));
        }
        break;
      case 'css_class':
        $css_class = $form_state->getValue('css_class');
        if (preg_match('/[^a-zA-Z0-9-_@ ]/', $css_class)) {
          $form_state->setError($form['css_class'], $this->t('CSS classes must be alphanumeric or dashes only.'));
        }
        break;
```