### PR TITLE
External Entities: external_entities_inline_entity_form_entity_form_alter() needs to check entity instance sooner

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -225,6 +225,9 @@
             "drupal/entity_embed": {
                 "3061050 - \"TypeError: originalGetFocusedWidget is not a function\" if drupalimage plugin button not used": "patches/originalgetfocusedwidget-not-function-3061050-2.patch"
             },
+            "drupal/external_entities": {
+                "3065268 - external_entities_inline_entity_form_entity_form_alter() needs to check entity instance sooner": "patches/external_entities-inline_entity_form_alter_check_type_sooner-3065268-2.patch"
+            },
             "drupal/linkit": {
               "3040749 - Drupal 8.7 no longer has a dedicated canonical route for media entities, breaks entity matcher deriver": "https://www.drupal.org/files/issues/2019-05-03/linkit-media-87-3040749-8.patch",
               "3063393 - Remove '/edit' from media entity paths": "patches/linkit-media_entity_update_canonical_path-3063393-2.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a899703e70bd3ace00b4e49e50d2dae1",
+    "content-hash": "99b9d68813dec53fc0ea6fd7a26892cf",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -3919,6 +3919,9 @@
                         "status": "not-covered",
                         "message": "Project has not opted into security advisory coverage!"
                     }
+                },
+                "patches_applied": {
+                    "3065268 - external_entities_inline_entity_form_entity_form_alter() needs to check entity instance sooner": "patches/external_entities-inline_entity_form_alter_check_type_sooner-3065268-2.patch"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",

--- a/patches/external_entities-inline_entity_form_alter_check_type_sooner-3065268-2.patch
+++ b/patches/external_entities-inline_entity_form_alter_check_type_sooner-3065268-2.patch
@@ -1,0 +1,19 @@
+diff --git a/external_entities.module b/external_entities.module
+index eeb5c66..961fc68 100755
+--- a/external_entities.module
++++ b/external_entities.module
+@@ -171,10 +171,12 @@ function external_entities_field_storage_config_edit_form_validate_cardinality(a
+  * Implements hook_inline_entity_form_entity_form_alter().
+  */
+ function external_entities_inline_entity_form_entity_form_alter(&$entity_form, FormStateInterface $form_state) {
+-  /* @var \Drupal\Core\Entity\FieldableEntityInterface $annotation_entity */
+   $annotation_entity = $entity_form['#entity'];
++  if (!$annotation_entity instanceof ExternalEntityInterface) {
++    return;
++  }
+   $external_entity = $form_state->getFormObject()->getEntity();
+-  if ($annotation_entity->isNew() && $external_entity instanceof ExternalEntityInterface) {
++  if ($annotation_entity->isNew()) {
+     $external_entity_type = $external_entity->getExternalEntityType();
+     if ($external_entity_type->isAnnotatable()
+       && $entity_form['#entity_type'] === $external_entity_type->getAnnotationEntityTypeId()


### PR DESCRIPTION
`external_entities_inline_entity_form_entity_form_alter()` is only interested in entities that are instances of `ExternalEntityInterface`; however, it doesn't check soon enough.

The following line can cause problems on some non-External Entity entities.

`$external_entity = $form_state->getFormObject()->getEntity();`

For example, trying to use IEF with Media entities will result in the following error:

`Error: Call to undefined method Drupal\\entity_browser\\Form\\EntityBrowserForm::getEntity() in /app/web/modules/contrib/external_entities/external_entities.module on line 176`

Patch is posted on Drupal.org: https://www.drupal.org/project/external_entities/issues/3065268