### PR TITLE
Enable Twig XDebug for development config split

### DIFF
--- a/config/sync/config_split.config_split.development.yml
+++ b/config/sync/config_split.config_split.development.yml
@@ -6,7 +6,8 @@ id: development
 label: Development
 description: ''
 folder: ../config/development
-module: {  }
+module:
+  twig_xdebug: 0
 theme: {  }
 blacklist: {  }
 graylist: {  }


### PR DESCRIPTION
Enable the [Twig Xdebug](https://www.drupal.org/project/twig_xdebug) module on the development config split.