### PR TITLE
Allow Card Block Type in Builder Page Layouts

### DIFF
--- a/config/sync/core.entity_view_display.node.builder_page.default.yml
+++ b/config/sync/core.entity_view_display.node.builder_page.default.yml
@@ -54,6 +54,7 @@ third_party_settings:
           - 'field_block:node:builder_page:body'
         'Custom block types':
           - accordion
+          - card
           - content
         Forms: {  }
         'Inline blocks':


### PR DESCRIPTION
I think Card was accidentally disallowed as an allowed block type for Builder Page layouts in a merge conflict resolution. This issue adds it back.