### PR TITLE
Limit Text Format options in different contexts.

### DIFF
--- a/config/sync/field.field.node.book.body.yml
+++ b/config/sync/field.field.node.book.body.yml
@@ -6,7 +6,14 @@ dependencies:
     - field.storage.node.body
     - node.type.book
   module:
+    - allowed_formats
     - text
+third_party_settings:
+  allowed_formats:
+    standard: standard
+    block_body: '0'
+    webform: '0'
+    plain_text: '0'
 _core:
   default_config_hash: AiTQTXl5A774TltS4-nZcpLmnMuEEtRq5lxnLYVtG6U
 id: node.book.body

--- a/config/sync/field.field.node.builder_page.body.yml
+++ b/config/sync/field.field.node.builder_page.body.yml
@@ -6,7 +6,14 @@ dependencies:
     - field.storage.node.body
     - node.type.builder_page
   module:
+    - allowed_formats
     - text
+third_party_settings:
+  allowed_formats:
+    standard: standard
+    block_body: '0'
+    webform: '0'
+    plain_text: '0'
 id: node.builder_page.body
 field_name: body
 entity_type: node

--- a/config/sync/field.field.node.person.n_person_bio.yml
+++ b/config/sync/field.field.node.person.n_person_bio.yml
@@ -10,7 +10,9 @@ dependencies:
     - text
 third_party_settings:
   allowed_formats:
+    block_body: block_body
     standard: '0'
+    webform: '0'
     plain_text: '0'
 id: node.person.n_person_bio
 field_name: n_person_bio


### PR DESCRIPTION
Currently on /node/add/builder_page you get the option to choose Standard or Webform for the text format.  Switching to Webform and saving can cause data loss.