### PR TITLE
UNL Twig: Fix class service definition

### DIFF
--- a/web/modules/custom/unl_twig/src/UnlTwigExtension.php
+++ b/web/modules/custom/unl_twig/src/UnlTwigExtension.php
@@ -17,9 +17,9 @@ class UnlTwigExtension extends \Twig_Extension {
   /**
    * {@inheritdoc}
    */
-  public function getFilters() {
+  public function getFunctions() {
     return [
-      new \Twig_SimpleFilter('intersect', 'array_intersect'),
+      new \Twig_SimpleFunction('intersect', 'array_intersect'),
     ];
   }
 

--- a/web/modules/custom/unl_twig/unl_twig.services.yml
+++ b/web/modules/custom/unl_twig/unl_twig.services.yml
@@ -1,5 +1,5 @@
 services:
-  unl_twig..twig_extension:
-    class: Drupal\unl_twig\unlTwigExtension
+  unl_twig.twig_extension:
+    class: Drupal\unl_twig\UnlTwigExtension
     tags:
       - { name: twig.extension }


### PR DESCRIPTION
In the current service definition, there are two issues:

1. `unl_twig..twig_extension` appears to be a typo with the extra period
2. `unlTwigExtension` should be `UnlTwigExtension`
```
services:
  unl_twig..twig_extension:
    class: Drupal\unl_twig\unlTwigExtension
    tags:
      - { name: twig.extension }
```
In `Drupal\unl_twig\UnlTwigExtension`, we should be using a function, not a filter, for the intersect functionality.

Example usage:
```
{% set haystack = ['cat', 'dog', 'fish', 'cow', 'horse'] %}
{% set needle = ['cat', 'dog', 'elephant'] %}
{% set output = intersect(haystack, needle) %}
{{ breakpoint() }}
```
Output returns `['cat', 'dog']`.