### PR TITLE
Add Configuration Inspector as dev dependency and load with Config Split

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -105,6 +105,7 @@
         "drupal/chosen": "^2.7",
         "drupal/ckeditor_config": "^2.0@RC",
         "drupal/config_ignore": "^2.1",
+        "drupal/config_role_split": "^1.0@beta",
         "drupal/config_split": "^1.4",
         "drupal/console": "^1.0.2",
         "drupal/core": "^8.7.0",

--- a/composer.json
+++ b/composer.json
@@ -151,6 +151,7 @@
         "zaporylie/composer-drupal-optimizations": "^1.0"
     },
     "require-dev": {
+        "drupal/config_inspector": "^1.0@beta",
         "drupal/twig_xdebug": "^1.1",
         "webflo/drupal-core-require-dev": "^8.7.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "80b183ea0b74da1d1af75232296acc0f",
+    "content-hash": "5fefd0d9cc8ac40f9e2b638dcdeb6fa3",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -2884,6 +2884,69 @@
             "support": {
                 "source": "http://cgit.drupalcode.org/config_ignore",
                 "issues": "http://drupal.org/project/config_ignore",
+                "irc": "irc://irc.freenode.org/drupal-contribute"
+            }
+        },
+        {
+            "name": "drupal/config_role_split",
+            "version": "1.0.0-beta1",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/config_role_split.git",
+                "reference": "8.x-1.0-beta1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/config_role_split-8.x-1.0-beta1.zip",
+                "reference": "8.x-1.0-beta1",
+                "shasum": "f6ccd4935907a557a25fbc19f8a14fe9a75e1606"
+            },
+            "require": {
+                "drupal/config_filter": "*",
+                "drupal/core": "*"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev"
+                },
+                "drupal": {
+                    "version": "8.x-1.0-beta1",
+                    "datestamp": "1503218943",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "Beta releases are not covered by Drupal security advisories."
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "authors": [
+                {
+                    "name": "Fabian Bircher",
+                    "homepage": "https://www.drupal.org/u/bircher",
+                    "email": "opensource@fabianbircher.com",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Nuvole Web",
+                    "email": "info@nuvole.org",
+                    "homepage": "http://nuvole.org",
+                    "role": "Maintainer"
+                }
+            ],
+            "description": "Config Role Split: Configuration filter for splitting permissions off roles",
+            "homepage": "https://www.drupal.org/project/config_role_split",
+            "keywords": [
+                "Drupal",
+                "configuration",
+                "configuration management"
+            ],
+            "support": {
+                "source": "http://cgit.drupalcode.org/config_role_split",
+                "issues": "https://www.drupal.org/project/issues/config_role_split",
                 "irc": "irc://irc.freenode.org/drupal-contribute"
             }
         },
@@ -12234,6 +12297,7 @@
         "drupal/block_form_alter": 10,
         "drupal/block_type_templates": 15,
         "drupal/ckeditor_config": 5,
+        "drupal/config_role_split": 10,
         "drupal/dcf": 10,
         "drupal/diff": 5,
         "drupal/entity_embed": 5,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f17c3adc63368d162f96a9b820508056",
+    "content-hash": "80b183ea0b74da1d1af75232296acc0f",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -10203,6 +10203,71 @@
             "time": "2019-08-09T09:27:26+00:00"
         },
         {
+            "name": "drupal/config_inspector",
+            "version": "1.0.0-beta2",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/config_inspector.git",
+                "reference": "8.x-1.0-beta2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/config_inspector-8.x-1.0-beta2.zip",
+                "reference": "8.x-1.0-beta2",
+                "shasum": "1f7b27c4b1c800a605a6d6583d0b1d120794658e"
+            },
+            "require": {
+                "drupal/core": "*"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev"
+                },
+                "drupal": {
+                    "version": "8.x-1.0-beta2",
+                    "datestamp": "1537879680",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "Beta releases are not covered by Drupal security advisories."
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "authors": [
+                {
+                    "name": "Gábor Hojtsy",
+                    "homepage": "https://www.drupal.org/user/4166"
+                },
+                {
+                    "name": "Jose Reyero",
+                    "homepage": "https://www.drupal.org/user/4299"
+                },
+                {
+                    "name": "aspilicious",
+                    "homepage": "https://www.drupal.org/user/172527"
+                },
+                {
+                    "name": "ilchovuchkov",
+                    "homepage": "https://www.drupal.org/user/3568458"
+                },
+                {
+                    "name": "vijaycs85",
+                    "homepage": "https://www.drupal.org/user/93488"
+                }
+            ],
+            "description": "Provides a configuration data and structure inspector tool",
+            "homepage": "https://drupal.org/project/config_inspector",
+            "support": {
+                "source": "https://cgit.drupalcode.org/config_inspector",
+                "issues": "https://drupal.org/project/issues/config_inspector",
+                "irc": "irc://irc.freenode.org/drupal-contribute"
+            }
+        },
+        {
             "name": "drupal/twig_xdebug",
             "version": "1.1.0",
             "source": {
@@ -12181,7 +12246,8 @@
         "unlcms/external_entities_unldirectory": 20,
         "unlcms/unl_cas": 20,
         "unlcms/unl_five": 20,
-        "unlcms/unl_multisite": 20
+        "unlcms/unl_multisite": 20,
+        "drupal/config_inspector": 10
     },
     "prefer-stable": true,
     "prefer-lowest": false,

--- a/config/sync/config_role_split.role_split.config_inspector.yml
+++ b/config/sync/config_role_split.role_split.config_inspector.yml
@@ -1,0 +1,11 @@
+uuid: a51c07ea-ddc8-4535-9e06-cacd8804b28f
+langcode: en
+status: true
+dependencies: {  }
+id: config_inspector
+label: 'Config Inspector'
+weight: 0
+mode: split
+roles:
+  administrator:
+    - 'inspect configuration'

--- a/config/sync/config_split.config_split.development.yml
+++ b/config/sync/config_split.config_split.development.yml
@@ -7,6 +7,7 @@ label: Development
 description: ''
 folder: ../config/development
 module:
+  config_inspector: 0
   twig_xdebug: 0
 theme: {  }
 blacklist: {  }

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -20,6 +20,7 @@ module:
   config: 0
   config_filter: 0
   config_ignore: 0
+  config_role_split: 0
   config_split: 0
   contextual: 0
   ctools: 0

--- a/config/sync/user.role.administrator.yml
+++ b/config/sync/user.role.administrator.yml
@@ -37,6 +37,7 @@ permissions:
   - 'administer block_content_type labels'
   - 'administer blocks'
   - 'administer book outlines'
+  - 'administer config role split'
   - 'administer configuration split'
   - 'administer content types'
   - 'administer dcf classes'


### PR DESCRIPTION
This issue adds the [Configuration Inspector](https://www.drupal.org/project/config_inspector) module and enables it on the 'development' split. It requires the Config Role Split module. See #133.