### PR TITLE
Update Block Content Permissions module

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2351,17 +2351,17 @@
         },
         {
             "name": "drupal/block_content_permissions",
-            "version": "1.6.0",
+            "version": "1.7.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/block_content_permissions.git",
-                "reference": "8.x-1.6"
+                "reference": "8.x-1.7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/block_content_permissions-8.x-1.6.zip",
-                "reference": "8.x-1.6",
-                "shasum": "03b3593ca3713955a3aa8519d8ac163961fd881a"
+                "url": "https://ftp.drupal.org/files/projects/block_content_permissions-8.x-1.7.zip",
+                "reference": "8.x-1.7",
+                "shasum": "86d4ba3970c627de48938c886a8a60f8ba6c4fd0"
             },
             "require": {
                 "drupal/core": "*"
@@ -2372,8 +2372,8 @@
                     "dev-1.x": "1.x-dev"
                 },
                 "drupal": {
-                    "version": "8.x-1.6",
-                    "datestamp": "1519041484",
+                    "version": "8.x-1.7",
+                    "datestamp": "1566763981",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"


### PR DESCRIPTION
Editors are unable to add Hero blocks to Builder Pages. Administrators are able to add Hero blocks, however.