### PR TITLE
Editors Unable to Add Inline Blocks

### DIFF
--- a/config/sync/user.role.editor.yml
+++ b/config/sync/user.role.editor.yml
@@ -22,6 +22,7 @@ permissions:
   - 'administer main menu items'
   - 'configure editable builder_page node layout overrides'
   - 'create accordion block content'
+  - 'create and edit custom blocks'
   - 'create book content'
   - 'create builder_page content'
   - 'create card block content'


### PR DESCRIPTION
Currently, Editors are unable to add inline blocks in Layout Builder. Administrators are able to add Inline Blocks, however.