### PR TITLE
Title Prints Twice on Person Nodes

### DIFF
--- a/web/themes/custom/unl_five_herbie/unl_five_herbie.theme
+++ b/web/themes/custom/unl_five_herbie/unl_five_herbie.theme
@@ -6,9 +6,9 @@
  */
 
 /**
- * Implements template_preprocess_page().
+ * Implements template_preprocess_region().
  */
-function unl_five_herbie_preprocess_page(&$variables) {
+function unl_five_herbie_preprocess_region(&$variables) {
   // Hide the hero region page title on Person nodes.
   $current_route = \Drupal::routeMatch();
   $node = $current_route->getParameters()->get('node');
@@ -21,12 +21,7 @@ function unl_five_herbie_preprocess_page(&$variables) {
         break;
     }
   }
-}
 
-/**
- * Implements template_preprocess_region().
- */
-function unl_five_herbie_preprocess_region(&$variables) {
   // Add the Hero field (s_n_hero) to the hero region template, region--hero.html.twig.
   if ($variables['region'] == 'hero') {
     $current_route = \Drupal::routeMatch();


### PR DESCRIPTION
On Person nodes, the title prints twice. The title in the 'hero' region should not print:

![Screen Shot 2019-10-02 at 4 10 16 PM](https://user-images.githubusercontent.com/1521132/66082406-ba19fe00-e52f-11e9-8775-92d828f0da96.png)

This was caused in unl_five: unlcms/unl_five#12. The solution is to move the relevant code from `unl_five_herbie_preprocess_page()` to `unl_five_herbie_preprocess_region()`.