### PR TITLE
Clean up Errors in unl_media_preprocess_filter_caption()

### DIFF
--- a/web/modules/custom/unl_media/unl_media.module
+++ b/web/modules/custom/unl_media/unl_media.module
@@ -144,10 +144,10 @@ function unl_media_preprocess_filter_caption(&$variables) {
   // Convert the markup to a DOM element.
   $element_string = $variables['node']->__toString();
   $dom = new DOMDocument();
-  $dom->loadHTML($element_string);
+  @$dom->loadHTML($element_string);
   // Only proceed if element is <drupal-entity>.
   $element = $dom->getElementsByTagName("drupal-entity");
-  if ($element->count() != 0) {
+  if (method_exists($element,'count') && $element->count() != 0) {
     $element = $element->item(0);
     $embed_display = $element->getAttribute('data-entity-embed-display');
 


### PR DESCRIPTION
Currently, I'm seeing two errors in the logs related to `unl_media_preprocess_filter_caption()`:

```
Warning: DOMDocument::loadHTML(): Tag drupal-entity invalid in Entity, line: 1 in unl_media_preprocess_filter_caption() (line 147 of /var/www/project-herbie/web/modules/custom/unl_media/unl_media.module)
```

```
Error: Call to undefined method DOMNodeList::count() in unl_media_preprocess_filter_caption() (line 150 of /var/www/project-herbie/web/modules/custom/unl_media/unl_media.module)
```