### PR TITLE
In render array, add custom data to 'data' item instead of 'content'

### DIFF
--- a/web/modules/custom/unl_twig/src/UnlTwigExtension.php
+++ b/web/modules/custom/unl_twig/src/UnlTwigExtension.php
@@ -20,6 +20,8 @@ class UnlTwigExtension extends \Twig_Extension {
   public function getFunctions() {
     return [
       new \Twig_SimpleFunction('intersect', 'array_intersect'),
+      new \Twig_SimpleFunction('intersect_key', 'array_intersect_key'),
+      new \Twig_SimpleFunction('array_flip', 'array_flip'),
     ];
   }
 

--- a/web/themes/custom/unl_five_herbie/templates/block/block--block-content-card.html.twig
+++ b/web/themes/custom/unl_five_herbie/templates/block/block--block-content-card.html.twig
@@ -33,7 +33,7 @@
 {% if card_presentation == 'solid' %}
   {% set attributes = attributes.addClass(['unl-frame-quad', 'unl-bg-cream']) %}
   {% set inner_wrapper_attributes = inner_wrapper_attributes.addClass(['dcf-pt-7', 'dcf-pr-7', 'dcf-pb-8', 'dcf-pl-7']) %}
-{% elseif card_presentation == 'transparent' and 'dcf-inverse' in content.section_classes %} 
+{% elseif card_presentation == 'transparent' and 'dcf-inverse' in data.section_classes %} 
   {% set attributes = attributes.addClass('unl-cream') %}
   {% if content.b_card_image.0 %}
     {% set inner_wrapper_attributes = inner_wrapper_attributes.addClass('dcf-pt-5') %}

--- a/web/themes/custom/unl_five_herbie/templates/field/field--block-content--b-card-body--card.html.twig
+++ b/web/themes/custom/unl_five_herbie/templates/field/field--block-content--b-card-body--card.html.twig
@@ -39,7 +39,7 @@
 {% set wrapper_attributes = create_attribute() %}
 
 {% for item in items %}
-  {% if item.content.card_presentation == 'solid' and 'dcf-inverse' in item.content.section_classes %}
+  {% if item.data.card_presentation == 'solid' and 'dcf-inverse' in item.data.section_classes %}
     {% set wrapper_attributes = wrapper_attributes.addClass('unl-darker-gray') %}
   {% endif %}
   <div{{ wrapper_attributes }}>

--- a/web/themes/custom/unl_five_herbie/templates/field/field--block-content--b-card-cta--card.html.twig
+++ b/web/themes/custom/unl_five_herbie/templates/field/field--block-content--b-card-cta--card.html.twig
@@ -51,17 +51,18 @@
 
 {% for item in items %}
   {# For transparent cards with dark section backgrounds #}
-  {% if item.content.card_presentation == 'transparent' and 'dcf-inverse' in item.content.section_classes %}
-    {% if item.content['cta_style'] == 'primary' %}
-      {% set bg_color = item.content.section_classes|intersect(item.content.dark_backgrounds)|first %}
-      {% set element_attributes = element_attributes.addClass(bg_color_mapping[bg_color]) %}
+  {% if item.data.card_presentation == 'transparent' and 'dcf-inverse' in item.data.section_classes %}
+    {% if item.data.cta_style == 'primary' %}
+      {% set section_classes = array_flip(item.data.section_classes) %}
+      {% set bg_color = intersect_key(bg_color_mapping, section_classes)|first %}
+      {% set element_attributes = element_attributes.addClass(bg_color) %}
       {% set element_attributes = element_attributes.addClass('dcf-btn-inverse-primary') %}
     {% elseif item.content['cta_style'] == 'secondary' %}
       {% set element_attributes = element_attributes.addClass('dcf-btn-inverse-secondary') %}
     {% endif %}
   {# For every other scenario #}
   {% else %}
-    {% if item.content['cta_style'] == 'primary' %}
+    {% if item.data.cta_style == 'primary' %}
       {% set element_attributes = element_attributes.addClass('dcf-btn-primary') %}
     {% elseif item.content['cta_style'] == 'secondary' %}
       {% set element_attributes = element_attributes.addClass('dcf-btn-secondary') %}

--- a/web/themes/custom/unl_five_herbie/templates/field/field--block-content--b-card-headline--card.html.twig
+++ b/web/themes/custom/unl_five_herbie/templates/field/field--block-content--b-card-headline--card.html.twig
@@ -41,15 +41,15 @@
 {% set link_attributes = create_attribute() %}
 
 {% for item in items %}
-  {% if item.content.card_presentation == 'transparent' and 'dcf-inverse' in item.content.section_classes %}
+  {% if item.data.card_presentation == 'transparent' and 'dcf-inverse' in item.data.section_classes %}
     {% set element_attributes = element_attributes.addClass('dcf-inverse') %}
     {% set link_attributes = link_attributes.addClass('dcf-inverse') %}
   {% endif %}
-  {% if item.content.subhead is not empty %}
+  {% if item.data.subhead is not empty %}
     {% set element_attributes = element_attributes.addClass('dcf-mb-0') %}
   {% endif %}
-  {% if item.content.headline_link is not empty %}
-    <h3 {{element_attributes}}><a {{ link_attributes }}href="{{ item.content.headline_link }}">{{ item.content }}</a></h3>
+  {% if item.data.headline_link is not empty %}
+    <h3 {{element_attributes}}><a {{ link_attributes }}href="{{ item.data.headline_link }}">{{ item.content }}</a></h3>
   {% else %}
     <h3 {{element_attributes}}>{{ item.content }}</h3>
   {% endif %}

--- a/web/themes/custom/unl_five_herbie/templates/field/field--block-content--b-card-overline--card.html.twig
+++ b/web/themes/custom/unl_five_herbie/templates/field/field--block-content--b-card-overline--card.html.twig
@@ -40,7 +40,7 @@
 {% set element_attributes = element_attributes.addClass(['dcf-subhead', 'unl-font-sans', 'unl-dark-gray']) %}
 
 {% for item in items %}
-  {% if item.content.card_presentation == 'transparent' and 'dcf-inverse' in item.content.section_classes %}
+  {% if item.data.card_presentation == 'transparent' and 'dcf-inverse' in item.data.section_classes %}
     {% set element_attributes = element_attributes.removeClass('unl-dark-gray') %}
   {% endif %}
   <p {{ element_attributes }}>{{ item.content }}</p>

--- a/web/themes/custom/unl_five_herbie/templates/field/field--block-content--b-card-subhead--card.html.twig
+++ b/web/themes/custom/unl_five_herbie/templates/field/field--block-content--b-card-subhead--card.html.twig
@@ -40,7 +40,7 @@
 {% set element_attributes = element_attributes.addClass(['dcf-subhead', 'dcf-mt-3', 'dcf-mb-5', 'unl-font-sans', 'unl-dark-gray']) %}
 
 {% for item in items %}
-  {% if item.content.card_presentation == 'transparent' and 'dcf-inverse' in item.content.section_classes %}
+  {% if item.data.card_presentation == 'transparent' and 'dcf-inverse' in item.data.section_classes %}
     {% set element_attributes = element_attributes.removeClass('unl-dark-gray') %}
   {% endif %}
   <p {{ element_attributes }}>{{ item.content }}</p>

--- a/web/themes/custom/unl_five_herbie/templates/field/field--block-content--b-cdcir-cta--card-circle-image.html.twig
+++ b/web/themes/custom/unl_five_herbie/templates/field/field--block-content--b-cdcir-cta--card-circle-image.html.twig
@@ -50,7 +50,7 @@
 %}
 
 {% for item in items %}
-  {% if 'dcf-inverse' in item.content.section_classes %}
+  {% if 'dcf-inverse' in item.data.section_classes %}
     {% set element_attributes = element_attributes.addClass('dcf-inverse') %}
   {% endif %}
   <a href="{{ item.content['#url'] }}" {{ element_attributes }}>{{ item.content['#title'] }}</a>

--- a/web/themes/custom/unl_five_herbie/templates/field/field--block-content--b-cdcir-headline--card-circle-image.html.twig
+++ b/web/themes/custom/unl_five_herbie/templates/field/field--block-content--b-cdcir-headline--card-circle-image.html.twig
@@ -41,12 +41,12 @@
 {% set link_attributes = create_attribute() %}
 
 {% for item in items %}
-  {% if 'dcf-inverse' in item.content.section_classes %}
+  {% if 'dcf-inverse' in item.data.section_classes %}
     {% set element_attributes = element_attributes.addClass('dcf-inverse') %}
     {% set link_attributes = link_attributes.addClass('dcf-inverse') %}
   {% endif %}
-  {% if item.content.headline_link is not empty %}
-    <h3 {{element_attributes}}><a {{ link_attributes }}href="{{ item.content.headline_link }}">{{ item.content }}</a></h3>
+  {% if item.data.headline_link is not empty %}
+    <h3 {{element_attributes}}><a {{ link_attributes }}href="{{ item.data.headline_link }}">{{ item.content }}</a></h3>
   {% else %}
     <h3 {{element_attributes}}>{{ item.content }}</h3>
   {% endif %}

--- a/web/themes/custom/unl_five_herbie/unl_five_herbie.theme
+++ b/web/themes/custom/unl_five_herbie/unl_five_herbie.theme
@@ -43,7 +43,7 @@ function unl_five_herbie_preprocess_region(&$variables) {
 function unl_five_herbie_preprocess_block(&$variables) {
   if (isset($variables['content']['#block_content'])) {
     $section_classes = $variables['content']['#block_content']->__get('#section_classes');
-    $variables['content']['section_classes'] = $section_classes;
+    $variables['data']['section_classes'] = $section_classes;
   }
   elseif (isset($variables['content']['#view'])) {
     $section_classes = $variables['content']['#view']->storage->get('#section_classes');
@@ -106,7 +106,7 @@ function unl_five_herbie_preprocess_field(&$variables) {
 
     // Set a variable with the b_hero_size CSS class since rendering the field
     // directly into the template will include breaking HTML comments if twig debugging is enabled.
-    $variables['hero_size_class'] = $variables['items'][0]['content']['b_hero_size'][0]['#markup'];
+    $variables['hero_size_class'] = $variables['items'][0]['data']['b_hero_size'][0]['#markup'];
    }
 
 
@@ -124,28 +124,28 @@ function unl_five_herbie_preprocess_field(&$variables) {
     case 'b_card_cta':
     case 'b_card_image':
       // Add to all Card fields.
-      $variables['items'][0]['content']['section_classes'] = $section_classes;
+      $variables['items'][0]['data']['section_classes'] = $section_classes;
 
       $card_presentation = $variables['element']['#object']->get('b_card_card_presentation')->getValue();
-      $variables['items'][0]['content']['card_presentation'] = isset($card_presentation[0]['value']) ? $card_presentation[0]['value'] : '';
+      $variables['items'][0]['data']['card_presentation'] = isset($card_presentation[0]['value']) ? $card_presentation[0]['value'] : '';
 
       // Loop through individual Card fields.
       switch ($field_name) {
         case 'b_card_headline':
           $headline_link = $variables['element']['#object']->get('b_card_headline_link')->first();
           $headline_link = !empty($headline_link) ? $headline_link->getUrl() : '';
-          $variables['items'][0]['content']['headline_link'] = $headline_link;
+          $variables['items'][0]['data']['headline_link'] = $headline_link;
 
           $overline = $variables['element']['#object']->get('b_card_overline')->getValue();
-          $variables['items'][0]['content']['overline'] = isset($overline[0]['value']) ? $overline[0]['value'] : '';
+          $variables['items'][0]['data']['overline'] = isset($overline[0]['value']) ? $overline[0]['value'] : '';
 
           $subhead = $variables['element']['#object']->get('b_card_subhead')->getValue();
-          $variables['items'][0]['content']['subhead'] = isset($subhead[0]['value']) ? $subhead[0]['value'] : '';
+          $variables['items'][0]['data']['subhead'] = isset($subhead[0]['value']) ? $subhead[0]['value'] : '';
           break;
 
         case 'b_card_cta':
           $cta_style = $variables['element']['#object']->get('b_card_cta_style')->getValue();
-          $variables['items'][0]['content']['cta_style'] = isset($cta_style[0]['value']) ? $cta_style[0]['value'] : '';
+          $variables['items'][0]['data']['cta_style'] = isset($cta_style[0]['value']) ? $cta_style[0]['value'] : '';
           break;
       }
 
@@ -161,14 +161,14 @@ function unl_five_herbie_preprocess_field(&$variables) {
     case 'b_cdcir_cta':
     case 'b_cdcir_image':
       // Add to all Card fields.
-      $variables['items'][0]['content']['section_classes'] = $section_classes;
+      $variables['items'][0]['data']['section_classes'] = $section_classes;
 
       // Loop through individual Card + Circle Image fields.
       switch ($field_name) {
         case 'b_cdcir_headline':
           $headline_link = $variables['element']['#object']->get('b_cdcir_headline_link')->first();
           $headline_link = !empty($headline_link) ? $headline_link->getUrl() : '';
-          $variables['items'][0]['content']['headline_link'] = $headline_link;
+          $variables['items'][0]['data']['headline_link'] = $headline_link;
           break;
       }
 


### PR DESCRIPTION
Currently, in unl_five_herbie, we're adding custom data to the `content` array within `items`. For example:
```
$variables['items'][0]['content']['section_classes'] = $section_classes;
```
Then in the twig templates, we access the data. E.g.:
```
{% elseif card_presentation == 'transparent' and 'dcf-inverse' in content.section_classes %}
```
This makes Drupal angry, and we get lots of messages in the log like
```
User error: "0" is an invalid render array key in Drupal\Core\Render\Element::children() (line 97 of /app/web/core/lib/Drupal/Core/Render/Element.php)
```
and
```
User error: "card_presentation" is an invalid render array key in Drupal\Core\Render\Element::children() (line 97 of /app/web/core/lib/Drupal/Core/Render/Element.php)
```

The proposed resolution is to use a separate `data` item. For example, in unl_five_herbie.theme:
```
$variables['items'][0]['data']['section_classes'] = $section_classes;
```
and in block--block-content-card.html.twig:
```
{% elseif card_presentation == 'transparent' and 'dcf-inverse' in data.section_classes %}
```