### PR TITLE
Set a minimum memory_limit value in settings for drush/cli usage

### DIFF
--- a/web/profiles/herbie/includes/settings.php.inc
+++ b/web/profiles/herbie/includes/settings.php.inc
@@ -33,7 +33,7 @@ $settings['file_private_path'] = dirname(debug_backtrace()[0]['file']) . '/files
  * for all PHP processes, including http requests, it is increased here (if
  * needed) only for command line usage.
  */
-if (PHP_SAPI == "cli") {
+if (PHP_SAPI == "cli" && ini_get('memory_limit') !== '-1') {
   // https://www.php.net/ini_get
   function return_bytes($val) {
     $val = trim($val);

--- a/web/profiles/herbie/includes/settings.php.inc
+++ b/web/profiles/herbie/includes/settings.php.inc
@@ -24,3 +24,35 @@ else {
  * A local file system path where private files will be stored.
  */
 $settings['file_private_path'] = dirname(debug_backtrace()[0]['file']) . '/files/private';
+
+/**
+ * Increase PHP's memory_limit for Drush.
+ *
+ * Drush site install needs more than the typical hosting default of 128M for
+ * the memory_limit. Rather than require that setting be increased on a server
+ * for all PHP processes, including http requests, it is increased here (if
+ * needed) only for command line usage.
+ */
+if (PHP_SAPI == "cli") {
+  // https://www.php.net/ini_get
+  function return_bytes($val) {
+    $val = trim($val);
+    $last = strtolower($val[strlen($val)-1]);
+    switch($last) {
+      case 'g':
+        $val *= 1024;
+      case 'm':
+        $val *= 1024;
+      case 'k':
+        $val *= 1024;
+    }
+
+    return $val;
+  }
+
+  $memory_limit = return_bytes(ini_get('memory_limit'));
+  if ($memory_limit < (256 * 1024 * 1024)) {
+    ini_set('memory_limit', '256M');
+  }
+}
+


### PR DESCRIPTION
Drush site install needs more than the typical hosting default of 128M for
the memory_limit. Rather than require that setting be increased on a server
for all PHP processes, including http requests, increase (if
 needed) only for command line usage.