### PR TITLE
Enable Update Manager on Development Config Split

### DIFF
--- a/config/development/update.settings.yml
+++ b/config/development/update.settings.yml
@@ -1,0 +1,12 @@
+check:
+  disabled_extensions: false
+  interval_days: 1
+fetch:
+  url: ''
+  max_attempts: 2
+  timeout: 30
+notification:
+  emails: {  }
+  threshold: all
+_core:
+  default_config_hash: 2QzULf0zovJQx3J06Y9rufzzfi-CY2CTTlEfJJh2Qyw

--- a/config/sync/config_split.config_split.development.yml
+++ b/config/sync/config_split.config_split.development.yml
@@ -9,8 +9,10 @@ folder: ../config/development
 module:
   config_inspector: 0
   twig_xdebug: 0
+  update: 0
 theme: {  }
-blacklist: {  }
+blacklist:
+  - update.settings
 graylist: {  }
 graylist_dependents: true
 graylist_skip_equal: true


### PR DESCRIPTION
This issue seeks to enable the Update Manager module on the Development config split. While it's not necessary to run Update Manager on production, it would be valuable to enable it on development so that developers can easily see which modules have updates available.