### PR TITLE
Update Field Group 8.x-3.0-rc1 from 8.x-1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -117,7 +117,7 @@
         "drupal/entity_embed": "^1.0@RC",
         "drupal/entity_usage": "^2.0@alpha",
         "drupal/external_entities": "^2.0@alpha",
-        "drupal/field_group": "^1.0",
+        "drupal/field_group": "^3.0",
         "drupal/honeypot": "^1.29",
         "drupal/image_effects": "^2.3",
         "drupal/imagemagick": "^2.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5fefd0d9cc8ac40f9e2b638dcdeb6fa3",
+    "content-hash": "50a9894899af1f34f9d109781a8fd77c",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -4268,17 +4268,17 @@
         },
         {
             "name": "drupal/field_group",
-            "version": "1.0.0",
+            "version": "3.0.0-rc1",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/field_group.git",
-                "reference": "8.x-1.0"
+                "reference": "8.x-3.0-rc1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/field_group-8.x-1.0.zip",
-                "reference": "8.x-1.0",
-                "shasum": "e8aa3fae5c3c5dec84644bb577996938d638a611"
+                "url": "https://ftp.drupal.org/files/projects/field_group-8.x-3.0-rc1.zip",
+                "reference": "8.x-3.0-rc1",
+                "shasum": "e291b5468c834a344e9aa6cafd3a76171d473a22"
             },
             "require": {
                 "drupal/core": "*"
@@ -4286,14 +4286,14 @@
             "type": "drupal-module",
             "extra": {
                 "branch-alias": {
-                    "dev-1.x": "1.x-dev"
+                    "dev-3.x": "3.x-dev"
                 },
                 "drupal": {
-                    "version": "8.x-1.0",
-                    "datestamp": "1510352885",
+                    "version": "8.x-3.0-rc1",
+                    "datestamp": "1558678323",
                     "security-coverage": {
-                        "status": "covered",
-                        "message": "Covered by Drupal's security advisory policy"
+                        "status": "not-covered",
+                        "message": "RC releases are not covered by Drupal security advisories."
                     }
                 }
             },
@@ -4326,7 +4326,7 @@
             "description": "Provides the field_group module.",
             "homepage": "https://www.drupal.org/project/field_group",
             "support": {
-                "source": "http://cgit.drupalcode.org/field_group"
+                "source": "https://git.drupalcode.org/project/field_group"
             }
         },
         {

--- a/config/sync/core.entity_form_display.media.file.default.yml
+++ b/config/sync/core.entity_form_display.media.file.default.yml
@@ -26,6 +26,7 @@ third_party_settings:
         description: ''
         required_fields: true
       label: Attributes
+      region: content
 id: media.file.default
 targetEntityType: media
 bundle: file

--- a/config/sync/core.entity_form_display.media.image.default.yml
+++ b/config/sync/core.entity_form_display.media.image.default.yml
@@ -31,6 +31,7 @@ third_party_settings:
         description: ''
         required_fields: true
       label: Attributes
+      region: content
 id: media.image.default
 targetEntityType: media
 bundle: image

--- a/config/sync/core.entity_form_display.media.remote_video.default.yml
+++ b/config/sync/core.entity_form_display.media.remote_video.default.yml
@@ -52,6 +52,7 @@ third_party_settings:
         description: ''
         required_fields: true
       label: Attributes
+      region: content
 id: media.remote_video.default
 targetEntityType: media
 bundle: remote_video

--- a/config/sync/core.entity_form_display.node.news.default.yml
+++ b/config/sync/core.entity_form_display.node.news.default.yml
@@ -30,6 +30,7 @@ third_party_settings:
         description: ''
         required_fields: true
       label: 'Lead image'
+      region: content
 id: node.news.default
 targetEntityType: node
 bundle: news

--- a/config/sync/core.entity_form_display.node.person.default.yml
+++ b/config/sync/core.entity_form_display.node.person.default.yml
@@ -36,6 +36,7 @@ third_party_settings:
         open: false
         required_fields: true
       label: '(Optional) UNL Directory Overrides'
+      region: content
 id: node.person.default
 targetEntityType: node
 bundle: person

--- a/config/sync/user.role.administrator.yml
+++ b/config/sync/user.role.administrator.yml
@@ -171,7 +171,6 @@ permissions:
   - 'view own unpublished content'
   - 'view own unpublished media'
   - 'view own webform submission'
-  - 'view own webform submission'
   - 'view person revisions'
   - 'view restricted block content'
   - 'view the administration theme'


### PR DESCRIPTION
This distribution is running Field Group 8.x-1.0, which is now unsupported. The proposed solution is to upgrade to 8.x-3.0-rc1.

There is an update script. Updated config is included in this PR.