### PR TITLE
Delegate Certain Site Configuration to Site Owners

### DIFF
--- a/config/sync/config_ignore.settings.yml
+++ b/config/sync/config_ignore.settings.yml
@@ -1,5 +1,9 @@
 ignored_config_entities:
-  - 'webform.webform.*'
+  0: 'webform.webform.*'
+  2: 'system.site:name'
+  4: 'system.site:mail'
+  6: 'system.site:slogan'
+  8: 'system.site:page.front'
 _core:
   default_config_hash: UVH1aJ4b44UM-VdPVN7hNNuuVqfReJxwfVeDQH1Hvsk
 enable_export_filtering: '1'

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -82,6 +82,7 @@ module:
   toolbar: 0
   unl_blocks: 0
   unl_cas: 0
+  unl_config: 0
   unl_five_ckeditor: 0
   unl_media: 0
   unl_mediahub: 0

--- a/config/sync/user.role.editor.yml
+++ b/config/sync/user.role.editor.yml
@@ -67,6 +67,7 @@ permissions:
   - 'revert book revisions'
   - 'revert builder_page revisions'
   - 'revert person revisions'
+  - 'unl administer site configuration'
   - 'update any accordion block content'
   - 'update any card block content'
   - 'update any card_circle_image block content'

--- a/web/modules/custom/unl_config/README.md
+++ b/web/modules/custom/unl_config/README.md
@@ -1,0 +1,34 @@
+INTRODUCTION
+------------
+
+This module allows for certain configuration to be managed by site owners on a sub-config object basis. For example, in the case of the `system.site` config object, it is possible to allow site owners to edit the _Site Name_ and _Default front page_ settings while denying edit access to other settings, such as _Email address_ or _Default 403 (access denied) page_.
+
+REQUIREMENTS
+------------
+
+ - Drupal 8
+ - Config Ignore
+
+INSTALLATION
+------------
+
+Install as you would normally install a contributed Drupal module. Visit:
+[https://www.drupal.org/docs/8/extending-drupal-8/installing-drupal-8-modules](https://www.drupal.org/docs/8/extending-drupal-8/installing-drupal-8-modules)
+for further information.
+
+USAGE AND CONFIGURATION
+-------------
+
+There are four components of functionality:
+
+## Permission
+This module adds the `unl administer site configuration` permission, which is used to provide access to certain routes where access would otherwise be controlled solely by the `administer site configuration` permission.
+
+## Alter route permission
+In order to grant access to routes for roles with the `unl administer site configuration` permission, this module provides a route subscriber service and an accompanying `RouteSubscriber` class. In this class, a given route's `_permission` requirement is modified to permit access using OR logic with the `administer site configuration` and the `unl administer site configuration` permissions. Either permission will now provide access to the route.
+
+## Alter form
+Now that a user with the `unl administer site configuration` permission has access to the route and its form page, access can be further restricted with `hook_form_FORM_ID_alter()`. A form field can be disabled by adding `'#disabled' => TRUE` to the form element's render array. This designation is enforced in the backend on submission by Drupal core. This restriction code is conditionally applied to roles without the `administer site configuration` permission.
+
+## Ignored configuration
+Finally, the Config Ignore configuration must be updated to ignore the configuration that site owners are allowed to edit.

--- a/web/modules/custom/unl_config/src/Routing/RouteSubscriber.php
+++ b/web/modules/custom/unl_config/src/Routing/RouteSubscriber.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Drupal\unl_config\Routing;
+
+use Drupal\Core\Routing\RouteSubscriberBase;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * Listens to the dynamic route events.
+ */
+class RouteSubscriber extends RouteSubscriberBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function alterRoutes(RouteCollection $collection) {
+    // Form: system_site_information_settings.
+    // Route: system.site_information_settings.
+    // Path: admin/config/system/site-information.
+    if ($route = $collection->get('system.site_information_settings')) {
+      // Add custom permission for route.
+      $permission = $route->getRequirement('_permission') . '+unl administer site configuration';
+      $route->setRequirement('_permission', $permission);
+    }
+  }
+
+}

--- a/web/modules/custom/unl_config/unl_config.info.yml
+++ b/web/modules/custom/unl_config/unl_config.info.yml
@@ -1,0 +1,11 @@
+name: 'UNL Configuration'
+description: 'Modifies configuration UI for UNL sites'
+package: UNL
+
+type: module
+core: 8.x
+
+version: 1.x
+
+dependencies:
+  - drupal:config_ignore

--- a/web/modules/custom/unl_config/unl_config.module
+++ b/web/modules/custom/unl_config/unl_config.module
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * @file
+ * This is the module customizes the configuration UI for UNLCMS.
+ */
+
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ *
+ * Form: system_site_information_settings.
+ * Route: system.site_information_settings.
+ * Path: admin/config/system/site-information.
+ */
+function unl_config_form_system_site_information_settings_alter(&$form, FormStateInterface &$form_state, $form_id) {
+  $user = \Drupal::currentUser();
+
+  // Disable certain configuration fields for non-administrators.
+  if (!$user->hasPermission('administer site configuration')) {
+    $form['error_page']['site_403']['#disabled'] = TRUE;
+    $form['error_page']['site_404']['#disabled'] = TRUE;
+  }
+
+}

--- a/web/modules/custom/unl_config/unl_config.permissions.yml
+++ b/web/modules/custom/unl_config/unl_config.permissions.yml
@@ -1,0 +1,2 @@
+unl administer site configuration:
+  title: 'UNL: Administer site configuration'

--- a/web/modules/custom/unl_config/unl_config.services.yml
+++ b/web/modules/custom/unl_config/unl_config.services.yml
@@ -1,0 +1,5 @@
+services:
+  unl_config.route_subscriber:
+    class: Drupal\unl_config\Routing\RouteSubscriber
+    tags:
+      - { name: event_subscriber }


### PR DESCRIPTION
This issue is a bit of a working prototype for one way that we can handle delegated configuration to site owners. It adds a new unl_config custom module.

This module allows for certain configuration to be managed by site owners on a sub-config object basis. For example, in the case of the `system.site` config object, it is possible to allow site owners to edit the _Site Name_ and _Default front page_ settings while denying edit access to other settings, such as _Email address_ or _Default 403 (access denied) page_.

There are four components of functionality:

## Permission
This module adds the `unl administer site configuration` permission, which is used to provide access to certain routes where access would otherwise be controlled solely by the `administer site configuration` permission.

## Alter route permission
In order to grant access to routes for roles with the `unl administer site configuration` permission, this module provides a route subscriber service and an accompanying `RouteSubscriber` class. In this class, a given route's `_permission` requirement is modified to permit access using OR logic with the `administer site configuration` and the `unl administer site configuration` permissions. Either permission will now provide access to the route.

## Alter form
Now that a user with the `unl administer site configuration` permission has access to the route and its form page, access can be further restricted with `hook_form_FORM_ID_alter()`. A form field can be disabled by adding `'#disabled' => TRUE` to the form element's render array. This designation is enforced in the backend on submission by Drupal core. This restriction code is conditionally applied to roles without the `administer site configuration` permission.

## Ignored configuration
Finally, the Config Ignore configuration must be updated to ignore the configuration that site owners are allowed to edit.