### PR TITLE
Add view permission for Accordion paragraph type

### DIFF
--- a/config/sync/user.role.anonymous.yml
+++ b/config/sync/user.role.anonymous.yml
@@ -11,3 +11,4 @@ is_admin: false
 permissions:
   - 'access content'
   - 'view media'
+  - 'view paragraph content accordion_item'

--- a/config/sync/user.role.authenticated.yml
+++ b/config/sync/user.role.authenticated.yml
@@ -19,3 +19,4 @@ permissions:
   - 'use text format standard'
   - 'use text format webform'
   - 'view media'
+  - 'view paragraph content accordion_item'


### PR DESCRIPTION
Currently, the "Accordion Item: View content" permission is not assigned to _Authenticated_ and _Anonymous_ roles. This means users with only those roles cannot see accordions.