### PR TITLE
Person: Add option to override photo

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -133,6 +133,7 @@
         "drupal/pathauto": "^1.3",
         "drupal/rabbit_hole": "^1.0@beta",
         "drupal/token": "^1.5",
+        "drupal/twig_tweak": "^2.4",
         "drupal/webform": "^5.2",
         "drush/drush": "^9.0.0",
         "harvesthq/chosen": "^1.8",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b2de850391a94a0fa45792c20ad75cda",
+    "content-hash": "9b948c2074acca60ae77cb6f74806c2f",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -3508,7 +3508,8 @@
                     "502430 - Allow the book outline functionality on non-book-enabled node types to be hidden": "patches/core_book-outline_permission-502430-80.patch",
                     "3008119 - Provide hook_oembed_providers_alter()": "patches/drupal-allow_alter_oembed_providers-3008119-4.patch",
                     "3060292 - Drupal\\media\\Entity\\Media::prepareSave should convert URL object metadata to string before saving": "patches/drupal_media-resource_convert_url_object_to_string-3060292-5.patch",
-                    "Custom - Allow '@' in CSS selectors for Views displays": "patches/custom-views-DisplayPluginBase-valid-css-selector.patch"
+                    "Custom - Allow '@' in CSS selectors for Views displays": "patches/custom-views-DisplayPluginBase-valid-css-selector.patch",
+                    "3080606 - Re-order Layout Builder sections": "patches/3080606-reorder-layout-sections-28.patch"
                 }
             },
             "autoload": {
@@ -5435,6 +5436,61 @@
             "homepage": "https://www.drupal.org/project/token",
             "support": {
                 "source": "http://cgit.drupalcode.org/token"
+            }
+        },
+        {
+            "name": "drupal/twig_tweak",
+            "version": "2.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/twig_tweak.git",
+                "reference": "8.x-2.4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/twig_tweak-8.x-2.4.zip",
+                "reference": "8.x-2.4",
+                "shasum": "fa175b46d2b69ce0f30344579a5861169c8467a4"
+            },
+            "require": {
+                "drupal/core": "^8.7"
+            },
+            "suggest": {
+                "symfony/var-dumper": "Better dump() function for debugging Twig variables"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "branch-alias": {
+                    "dev-2.x": "2.x-dev"
+                },
+                "drupal": {
+                    "version": "8.x-2.4",
+                    "datestamp": "1563099329",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "authors": [
+                {
+                    "name": "Chi",
+                    "homepage": "https://www.drupal.org/user/556138"
+                }
+            ],
+            "description": "A Twig extension with some useful functions and filters for Drupal development.",
+            "homepage": "https://www.drupal.org/project/twig_tweak",
+            "keywords": [
+                "Drupal",
+                "Twig"
+            ],
+            "support": {
+                "source": "https://git.drupalcode.org/project/twig_tweak",
+                "issues": "https://www.drupal.org/project/issues/twig_tweak"
             }
         },
         {

--- a/config/sync/core.entity_form_display.node.person.default.yml
+++ b/config/sync/core.entity_form_display.node.person.default.yml
@@ -7,12 +7,15 @@ dependencies:
     - field.field.node.person.n_person_bio
     - field.field.node.person.n_person_email
     - field.field.node.person.n_person_phone
+    - field.field.node.person.n_person_photo
     - field.field.node.person.n_person_position
     - field.field.node.person.n_person_unldirectoryreference
     - field.field.node.person.n_person_website
+    - image.style.1_1_240x240
     - node.type.person
   module:
     - field_group
+    - image
     - link
     - path
     - telephone
@@ -23,6 +26,7 @@ third_party_settings:
       children:
         - n_person_position
         - n_person_bio
+        - n_person_photo
         - n_person_phone
         - n_person_email
         - n_person_address
@@ -49,7 +53,7 @@ content:
     settings: {  }
     third_party_settings: {  }
   n_person_address:
-    weight: 12
+    weight: 13
     settings:
       size: 60
       placeholder: ''
@@ -66,7 +70,7 @@ content:
     type: text_textarea_with_summary
     region: content
   n_person_email:
-    weight: 11
+    weight: 12
     settings:
       size: 60
       placeholder: ''
@@ -74,11 +78,19 @@ content:
     type: email_default
     region: content
   n_person_phone:
-    weight: 10
+    weight: 11
     settings:
       placeholder: ''
     third_party_settings: {  }
     type: telephone_default
+    region: content
+  n_person_photo:
+    weight: 10
+    settings:
+      preview_image_style: 1_1_240x240
+      progress_indicator: throbber
+    third_party_settings: {  }
+    type: image_image
     region: content
   n_person_position:
     weight: 8
@@ -98,7 +110,7 @@ content:
     type: entity_reference_autocomplete
     region: content
   n_person_website:
-    weight: 13
+    weight: 14
     settings:
       placeholder_url: ''
       placeholder_title: ''

--- a/config/sync/core.entity_view_display.node.person.default.yml
+++ b/config/sync/core.entity_view_display.node.person.default.yml
@@ -7,11 +7,14 @@ dependencies:
     - field.field.node.person.n_person_bio
     - field.field.node.person.n_person_email
     - field.field.node.person.n_person_phone
+    - field.field.node.person.n_person_photo
     - field.field.node.person.n_person_position
     - field.field.node.person.n_person_unldirectoryreference
     - field.field.node.person.n_person_website
+    - image.style.1_1_240x240
     - node.type.person
   module:
+    - image
     - link
     - telephone
     - text
@@ -55,6 +58,15 @@ content:
       title: ''
     third_party_settings: {  }
     type: telephone_link
+    region: content
+  n_person_photo:
+    weight: 109
+    label: hidden
+    settings:
+      image_style: 1_1_240x240
+      image_link: ''
+    third_party_settings: {  }
+    type: image
     region: content
   n_person_position:
     weight: 103

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -82,6 +82,7 @@ module:
   text: 0
   token: 0
   toolbar: 0
+  twig_tweak: 0
   unl_blocks: 0
   unl_cas: 0
   unl_config: 0

--- a/config/sync/field.field.node.person.n_person_photo.yml
+++ b/config/sync/field.field.node.person.n_person_photo.yml
@@ -1,0 +1,38 @@
+uuid: 79f48c36-c2ec-451c-854c-f9c45b84c2de
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.n_person_photo
+    - node.type.person
+  module:
+    - image
+id: node.person.n_person_photo
+field_name: n_person_photo
+entity_type: node
+bundle: person
+label: Photo
+description: 'Images should conform to a 1:1 aspect ratio. Automatic cropping will be applied to images.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  file_directory: 'node/person/photo/[date:custom:Y]-[date:custom:m]'
+  file_extensions: 'png gif jpg jpeg'
+  max_filesize: '40 MB'
+  max_resolution: 5000x5000
+  min_resolution: 240x240
+  alt_field: false
+  alt_field_required: true
+  title_field: false
+  title_field_required: false
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  handler: 'default:file'
+  handler_settings: {  }
+field_type: image

--- a/config/sync/field.storage.node.n_person_photo.yml
+++ b/config/sync/field.storage.node.n_person_photo.yml
@@ -1,0 +1,30 @@
+uuid: f54de97e-8692-4d9a-a440-82d772a172b3
+langcode: en
+status: true
+dependencies:
+  module:
+    - file
+    - image
+    - node
+id: node.n_person_photo
+field_name: n_person_photo
+entity_type: node
+type: image
+settings:
+  uri_scheme: public
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  target_type: file
+  display_field: false
+  display_default: false
+module: image
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/themes/custom/unl_five_herbie/templates/node/node--person.html.twig
+++ b/web/themes/custom/unl_five_herbie/templates/node/node--person.html.twig
@@ -24,8 +24,10 @@
 
         <div class="vcard faculty dcf-measure" data-uid="{{ node.n_person_unldirectoryreference.entity.ee_unldir_uid.value }}" data-preferred-name="{{ label }}" itemscope itemtype="http://schema.org/Person">
           <span class="card-profile dcf-d-block dcf-mb-3 dcf-h-10 dcf-w-10 dcf-ratio dcf-ratio-1x1">
-            {% if node.field_person_portrait.value %}
-              {{ content.field_person_portrait }}
+            {% if node.n_person_photo.value %}
+              {% set fid = node.n_person_photo.target_id %}
+              {% set alt = 'Avatar for ' ~ node.label  %}
+              {{ drupal_image(fid, '1_1_240x240', {alt: alt, itemprop: 'image', class: 'photo profile_pic dcf-ratio-child dcf-circle dcf-d-block dcf-obj-fit-cover'}) }}
             {% else  %}
               <img class="photo profile_pic dcf-ratio-child dcf-circle dcf-d-block dcf-obj-fit-cover" itemprop="image" src="{{ node.n_person_unldirectoryreference.entity.ee_unldir_imageurl.value }}?s=large" alt="Avatar for {{ label }}" />
             {% endif %}

--- a/web/themes/custom/unl_five_herbie/templates/node/node--person.html.twig
+++ b/web/themes/custom/unl_five_herbie/templates/node/node--person.html.twig
@@ -27,7 +27,7 @@
             {% if node.field_person_portrait.value %}
               {{ content.field_person_portrait }}
             {% else  %}
-              <img class="photo profile_pic dcf-ratio-child dcf-circle dcf-d-block dcf-obj-fit-cover" itemprop="image" src="{{ node.n_person_unldirectoryreference.entity.ee_unldir_imageurl.value }}" alt="Avatar for {{ label }}" />
+              <img class="photo profile_pic dcf-ratio-child dcf-circle dcf-d-block dcf-obj-fit-cover" itemprop="image" src="{{ node.n_person_unldirectoryreference.entity.ee_unldir_imageurl.value }}?s=large" alt="Avatar for {{ label }}" />
             {% endif %}
           </span>
           <div class="vcardInfo unl-font-sans">


### PR DESCRIPTION
Currently, the photo for a Person node is pulled in with the external entity. This issue seeks to allow for an editor to override the photo.