### PR TITLE
Enforce trailing slashes on URLs and Links

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -94,6 +94,7 @@ module:
   unl_menu: 0
   unl_news: 0
   unl_pathauto: 0
+  unl_trailing_slash: 0
   unl_twig: 0
   unl_user: 0
   unl_utility: 0

--- a/web/modules/custom/unl_trailing_slash/README.md
+++ b/web/modules/custom/unl_trailing_slash/README.md
@@ -1,0 +1,22 @@
+INTRODUCTION
+------------
+
+This module rewrites all paths to end with a trailing slash. It is designed
+to be compatible with the Redirect module.
+
+REQUIREMENTS
+------------
+
+ - Drupal 8 or Drupal 9
+
+INSTALLATION
+------------
+
+Install as you would normally install a contributed Drupal module. Visit:
+[https://www.drupal.org/docs/8/extending-drupal-8/installing-drupal-8-modules](https://www.drupal.org/docs/8/extending-drupal-8/installing-drupal-8-modules)
+for further information.
+
+USAGE AND CONFIGURATION
+-------------
+
+There is no configuration.

--- a/web/modules/custom/unl_trailing_slash/src/PathProcessor/TrailingSlashOutboundPathProcessor.php
+++ b/web/modules/custom/unl_trailing_slash/src/PathProcessor/TrailingSlashOutboundPathProcessor.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Drupal\unl_trailing_slash\PathProcessor;
+
+use Drupal\Core\PathProcessor\OutboundPathProcessorInterface;
+use Drupal\Core\Render\BubbleableMetadata;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Class TrailingSlashOutboundPathProcessor.
+ */
+class TrailingSlashOutboundPathProcessor implements OutboundPathProcessorInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function processOutbound($path, &$options = [], Request $request = NULL, BubbleableMetadata $bubbleable_metadata = NULL) {
+    // Add trailing slash to all paths if one is not present.
+    return rtrim($path, '/') . '/';
+  }
+
+}

--- a/web/modules/custom/unl_trailing_slash/src/PathProcessor/TrailingSlashOutboundPathProcessor.php
+++ b/web/modules/custom/unl_trailing_slash/src/PathProcessor/TrailingSlashOutboundPathProcessor.php
@@ -15,8 +15,12 @@ class TrailingSlashOutboundPathProcessor implements OutboundPathProcessorInterfa
    * {@inheritdoc}
    */
   public function processOutbound($path, &$options = [], Request $request = NULL, BubbleableMetadata $bubbleable_metadata = NULL) {
-    // Add trailing slash to all paths if one is not present.
-    return rtrim($path, '/') . '/';
+    $path = rtrim($path, '/');
+    // If the path does not end in a file extension, then add a trailing slash.
+    if (!pathinfo($path, PATHINFO_EXTENSION)) {
+      $path = $path . '/';
+    }
+    return $path;
   }
 
 }

--- a/web/modules/custom/unl_trailing_slash/unl_trailing_slash.info.yml
+++ b/web/modules/custom/unl_trailing_slash/unl_trailing_slash.info.yml
@@ -1,0 +1,4 @@
+name: UNL Trailing Slash
+type: module
+description: Adds a trailing slash at the end of all paths
+core_version_requirement: ^8 || ^9

--- a/web/modules/custom/unl_trailing_slash/unl_trailing_slash.services.yml
+++ b/web/modules/custom/unl_trailing_slash/unl_trailing_slash.services.yml
@@ -1,0 +1,5 @@
+services:
+  unl_trailing_slash.path_processor_trailing_slash:
+    class: Drupal\unl_trailing_slash\PathProcessor\TrailingSlashOutboundPathProcessor
+    tags:
+      - { name: path_processor_outbound, priority: -1 }


### PR DESCRIPTION
Followup of #180 

Reason: Web audit needs a trailing slash to process a path as a site root.  For example: https://engineering.unl.edu/civil/ will be the homepage for a Civil Eng site.  If the URL is merely https://engineering.unl.edu/civil then that is just a page on the https://engineering.unl.edu/ site.

Things needed:

1. This module rewrites Drupal generated links to add the slash on the end:
https://www.drupal.org/project/trailing_slash 

2. The other piece is triggering a redirect when the slash isn't present.  In D7 the Global Redirect module (and UNL's patched Redirect module) did this.  In D8, we probably just want to do the htaccess method on https://www.drupal.org/project/trailing_slash :

```
RewriteEngine On
RewriteBase /
RewriteCond %{REQUEST_METHOD} !=post [NC]
RewriteRule ^(.*(?:^|/)[^/\.]+)$ $1/ [L,R=301]
```