### PR TITLE
Check !function_exists('return_bytes') in settings

### DIFF
--- a/web/profiles/herbie/includes/settings.php.inc
+++ b/web/profiles/herbie/includes/settings.php.inc
@@ -46,20 +46,22 @@ $settings['file_private_path'] = dirname(debug_backtrace()[0]['file']) . '/files
  * needed) only for command line usage.
  */
 if (PHP_SAPI == "cli" && ini_get('memory_limit') !== '-1') {
-  // https://www.php.net/ini_get
-  function return_bytes($val) {
-    $val = trim($val);
-    $last = strtolower($val[strlen($val)-1]);
-    switch($last) {
-      case 'g':
-        $val *= 1024;
-      case 'm':
-        $val *= 1024;
-      case 'k':
-        $val *= 1024;
-    }
+  if (!function_exists('return_bytes')) {
+    // https://www.php.net/ini_get
+    function return_bytes($val) {
+      $val = trim($val);
+      $last = strtolower($val[strlen($val) - 1]);
+      switch ($last) {
+        case 'g':
+          $val *= 1024;
+        case 'm':
+          $val *= 1024;
+        case 'k':
+          $val *= 1024;
+      }
 
-    return $val;
+      return $val;
+    }
   }
 
   $memory_limit = return_bytes(ini_get('memory_limit'));

--- a/web/profiles/herbie/includes/settings.php.inc
+++ b/web/profiles/herbie/includes/settings.php.inc
@@ -46,6 +46,12 @@ $settings['file_private_path'] = dirname(debug_backtrace()[0]['file']) . '/files
  * needed) only for command line usage.
  */
 if (PHP_SAPI == "cli" && ini_get('memory_limit') !== '-1') {
+  // This file is loaded with an 'include' statement in settings.php. In certain
+  // situations (such as drush site:install) settings.php is loaded multiple
+  // times, therefore this file is included multiple times, so this function
+  // needs to avoid being defined twice. This file could be loaded with
+  // 'include_once' instead but that was not done because it might
+  // negatively affect setting prioritization/order.
   if (!function_exists('return_bytes')) {
     // https://www.php.net/ini_get
     function return_bytes($val) {


### PR DESCRIPTION
Running some Drush commands like sql:create and site-install results in 

PHP Fatal error:  Cannot redeclare return_bytes() ...

as the profile/herbie/includes/settings.php.inc gets included twice during execution.

One option would be to do include_once in default.settings.php but just checking if the function exists may be preferable to not hamper the subsequent inclusion and priority concerns of the file's contents.