### PR TITLE
Patch Core Media for Embed Edit Link Styling

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -212,7 +212,8 @@
                 "Custom - Allow '@' in CSS selectors for Views displays": "patches/custom-views-DisplayPluginBase-valid-css-selector.patch",
                 "3080606 - Re-order Layout Builder sections": "patches/3080606-reorder-layout-sections-28.patch",
                 "3100066 - 'Convert line breaks into HTML' filter should exclude <drupal-media> tag": "patches/3100066-2.patch",
-                "2897377 - data-drupal-selector is set to random value": "patches/drupal-data_drupal_selector-2897377-20.patch"
+                "2897377 - data-drupal-selector is set to random value": "patches/drupal-data_drupal_selector-2897377-20.patch",
+                "3092795 - Restore styling for embedded media edit button": "patches/3092795-22.patch"
             },
             "drupal/block_content_permissions": {
                 "2920739 - Allow accessing the 'Custom block library' page without 'Administer blocks' permission": "patches/block_content_permissions-access_listing_page-2920739-23.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "55c4ee77edd7f7db226ffc2dbb197e34",
+    "content-hash": "a7b4a6078982241d4d16c281dbdbc2d7",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -3173,7 +3173,8 @@
                     "Custom - Allow '@' in CSS selectors for Views displays": "patches/custom-views-DisplayPluginBase-valid-css-selector.patch",
                     "3080606 - Re-order Layout Builder sections": "patches/3080606-reorder-layout-sections-28.patch",
                     "3100066 - 'Convert line breaks into HTML' filter should exclude <drupal-media> tag": "patches/3100066-2.patch",
-                    "2897377 - data-drupal-selector is set to random value": "patches/drupal-data_drupal_selector-2897377-20.patch"
+                    "2897377 - data-drupal-selector is set to random value": "patches/drupal-data_drupal_selector-2897377-20.patch",
+                    "3092795 - Restore styling for embedded media edit button": "patches/3092795-22.patch"
                 }
             },
             "autoload": {

--- a/patches/3092795-22.patch
+++ b/patches/3092795-22.patch
@@ -1,0 +1,56 @@
+diff --git a/core/modules/media/css/plugins/drupalmedia/ckeditor.drupalmedia.css b/core/modules/media/css/plugins/drupalmedia/ckeditor.drupalmedia.css
+index 82923ff63e..0232f3554e 100644
+--- a/core/modules/media/css/plugins/drupalmedia/ckeditor.drupalmedia.css
++++ b/core/modules/media/css/plugins/drupalmedia/ckeditor.drupalmedia.css
+@@ -22,14 +22,6 @@ drupal-media {
+ }
+ 
+ /**
+- * Fix positioning without delete button. Can be removed with this issue:
+- * @see https://www.drupal.org/project/drupal/issues/3074859
+- */
+-drupal-media .media-library-item__edit {
+-  right: 10px;
+-}
+-
+-/**
+  * Allow alignment to display in CKEditor.
+  */
+ drupal-media[data-align=left],
+@@ -39,3 +31,36 @@ drupal-media[data-align=right] {
+ drupal-media[data-align=center] {
+   display: flex;
+ }
++
++/**
++ * Embedded media edit button styles.
++ *
++ * We have to override the .button styles since buttons make heavy use of
++ * background and border property changes.
++ */
++drupal-media .media-library-item__edit,
++drupal-media .media-library-item__edit:hover,
++drupal-media .media-library-item__edit:focus {
++  position: absolute;
++  z-index: 1;
++  top: 10px;
++  overflow: hidden;
++  width: 21px;
++  height: 21px;
++  margin: 5px;
++  padding: 0;
++  transition: 0.2s border-color;
++  color: transparent;
++  border: 2px solid #ccc;
++  border-radius: 20px;
++  background-size: 13px;
++  text-shadow: none;
++  font-size: 0;
++  cursor: pointer;
++}
++
++drupal-media .media-library-item__edit {
++  right: 10px;
++  background: url("../../../../../misc/icons/787878/pencil.svg") #fff center no-repeat;
++  background-size: 13px;
++}


### PR DESCRIPTION
[[regression] Restore styling for embedded media edit button in Seven theme](https://www.drupal.org/project/drupal/issues/3092795)

When core styling was refactored, the styles used for the MediaEmbed edit button in CKEditor got lost in the shuffle. As a result, instead of the hover pencil icon, we're left with an ugly button.