### PR TITLE
Provide interstitial breadcrumb config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -147,6 +147,7 @@
         "unl/wdntemplates": "^5.0",
         "unlcms/external_entities_unldirectory": "dev-8.x-2.x",
         "unlcms/project-herbie-composer-plugin": "^1.0",
+        "unlcms/unl_breadcrumbs": "^1.0",
         "unlcms/unl_cas": "dev-8.x-1.x",
         "unlcms/unl_five": "dev-8.x-5.0.x",
         "unlcms/unl_multisite": "dev-8.x-1.x",

--- a/composer.lock
+++ b/composer.lock
@@ -9500,12 +9500,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/unlcms/unl_five.git",
-                "reference": "55543ab3b7cb63aec1abe93792c2d8855eac875a"
+                "reference": "f6edb61032f881a7e1cd31b2c19bb99329c74743"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/unlcms/unl_five/zipball/55543ab3b7cb63aec1abe93792c2d8855eac875a",
-                "reference": "55543ab3b7cb63aec1abe93792c2d8855eac875a",
+                "url": "https://api.github.com/repos/unlcms/unl_five/zipball/f6edb61032f881a7e1cd31b2c19bb99329c74743",
+                "reference": "f6edb61032f881a7e1cd31b2c19bb99329c74743",
                 "shasum": ""
             },
             "type": "drupal-theme",
@@ -9518,7 +9518,7 @@
                 }
             ],
             "description": "UNLedu Framework 5.0 theme.",
-            "time": "2020-02-21T00:48:36+00:00"
+            "time": "2020-03-09T20:53:38+00:00"
         },
         {
             "name": "unlcms/unl_multisite",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4f58edec8561d9cf006a0b7cc9a022e3",
+    "content-hash": "3d0f5dc2af0820988d8c3e5033b292c6",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -9464,6 +9464,35 @@
                 "issues": "https://github.com/unlcms/project-herbie-composer-plugin/issues"
             },
             "time": "2019-04-02T21:29:08+00:00"
+        },
+        {
+            "name": "unlcms/unl_breadcrumbs",
+            "version": "1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/unlcms/unl_breadcrumbs.git",
+                "reference": "267d1a49eb73c40f36a1f8e929e8afc0ce481aaa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/unlcms/unl_breadcrumbs/zipball/267d1a49eb73c40f36a1f8e929e8afc0ce481aaa",
+                "reference": "267d1a49eb73c40f36a1f8e929e8afc0ce481aaa",
+                "shasum": ""
+            },
+            "type": "drupal-module",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "authors": [
+                {
+                    "name": "Chris Burge",
+                    "homepage": "https://www.drupal.org/u/chris-burge",
+                    "role": "Maintainer"
+                }
+            ],
+            "description": "UNL breadcrumb implementation",
+            "time": "2020-02-20T19:49:15+00:00"
         },
         {
             "name": "unlcms/unl_cas",

--- a/config/sync/config_ignore.settings.yml
+++ b/config/sync/config_ignore.settings.yml
@@ -24,11 +24,12 @@ ignored_config_entities:
   44: ~block.block.unl_five_local_tasks
   46: ~block.block.unl_five_messages
   48: ~block.block.unl_five_page_title
-  50: 'webform.webform.*'
-  52: 'system.site:name'
-  54: 'system.site:mail'
-  56: 'system.site:slogan'
-  58: 'system.site:page.front'
+  50: 'system.site:name'
+  52: 'system.site:mail'
+  54: 'system.site:slogan'
+  56: 'system.site:page.front'
+  58: unl_breadcrumbs.settings
+  60: 'webform.webform.*'
 _core:
   default_config_hash: UVH1aJ4b44UM-VdPVN7hNNuuVqfReJxwfVeDQH1Hvsk
 enable_export_filtering: '1'

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -83,6 +83,7 @@ module:
   toolbar: 0
   twig_tweak: 0
   unl_blocks: 0
+  unl_breadcrumbs: 0
   unl_cas: 0
   unl_config: 0
   unl_five_ckeditor: 0

--- a/config/sync/user.role.administrator.yml
+++ b/config/sync/user.role.administrator.yml
@@ -79,6 +79,7 @@ permissions:
   - 'administer taxonomy_term fields'
   - 'administer taxonomy_term form display'
   - 'administer themes'
+  - 'administer unl breadcrumbs'
   - 'administer unl_directory_entry display'
   - 'administer unl_directory_entry fields'
   - 'administer unl_directory_entry form display'


### PR DESCRIPTION
For all framework sites, "Nebraska" (linked to www.unl.edu) should be the root breadcrumb. An organization may or may not be the direct organizational child of "Nebraska"; however, we need to maintain a complete breadcrumb trail.

For example, there exists a College of Example Studies. Within the College, there is a Fictional Center of Excellent Examples. Each has its own website.

All breadcrumbs for the College site should start with the following:
Nebraska > College of Example Studies (instead of "Home")

All breadcrumbs for the Fictional Center should start with the following:
Nebraska > College of Example Studies > Fictional Center of Excellent Examples (instead of "Home")

We need to be able to add interstitial breadcrumbs on a site-wide basis to accomplish this.

## Proposed Solution

- Intercept breadcrumbs when they're being rendered for a page and insert the interstitial breadcrumbs.
- Configuration will be stored as Drupal config. It will be managed from settings page.

## unl_five Considerations

Currently, breadcrumb behavior is being modified by the unl_five theme. It does two things:

1. Replace the root breadcrumb with "Nebraska" with a link to "www.unl.edu"
2. Appends the current page title as unlinked text.

Should this behavior be moved to a custom module and integrated into the functionality contemplated herein?