### PR TITLE
Add string search methods to UNLUtilityTrait

### DIFF
--- a/web/modules/custom/unl_utility/src/UNLUtilityTrait.php
+++ b/web/modules/custom/unl_utility/src/UNLUtilityTrait.php
@@ -57,4 +57,78 @@ trait UNLUtilityTrait {
     }
   }
 
+  /**
+   * Utility method that determines if a string begins with another string.
+   *
+   * @param string $string
+   *   The string being being searched.
+   * @param string $subString
+   *   The string being searched for.
+   * @param bool $caseSensitive
+   *   Whether or nor the search should be case sensitive.
+   */
+  public static function stringStartsWith($string, $subString, $caseSensitive = TRUE) {
+    if ($caseSensitive === FALSE) {
+      $string = mb_strtolower($string);
+      $subString = mb_strtolower($subString);
+    }
+
+    if (mb_substr($string, 0, mb_strlen($subString)) == $subString) {
+      return TRUE;
+    }
+    else {
+      return FALSE;
+    }
+  }
+
+  /**
+   * Utility method that determines if a string ends with another string.
+   *
+   * @param string $string
+   *   The string being being searched.
+   * @param string $subString
+   *   The string being searched for.
+   * @param bool $caseSensitive
+   *   Whether or nor the search should be case sensitive.
+   */
+  public static function stringEndsWith($string, $subString, $caseSensitive = TRUE) {
+    if ($caseSensitive === FALSE) {
+      $string = mb_strtolower($string);
+      $subString = mb_strtolower($subString);
+    }
+
+    $strlen = strlen($string);
+    $subStringLength = strlen($subString);
+
+    if ($subStringLength > $strlen) {
+      return FALSE;
+    }
+
+    return substr_compare($string, $subString, $strlen - $subStringLength, $subStringLength) === 0;
+  }
+
+  /**
+   * Method that determines if a string in contained within another string.
+   *
+   * @param string $haystack
+   *   The string being being searched.
+   * @param string $needle
+   *   The string being searched for.
+   * @param bool $caseSensitive
+   *   Whether or nor the search should be case sensitive.
+   */
+  public static function stringContains($haystack, $needle, $caseSensitive = TRUE) {
+    if ($caseSensitive === FALSE) {
+      $haystack = mb_strtolower($haystack);
+      $needle = mb_strtolower($needle);
+    }
+
+    if (mb_substr_count($haystack, $needle) > 0) {
+      return TRUE;
+    }
+    else {
+      return FALSE;
+    }
+  }
+
 }

--- a/web/modules/custom/unl_utility/tests/src/unit/StringTest.php
+++ b/web/modules/custom/unl_utility/tests/src/unit/StringTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Drupal\Tests\unl_utility\Unit;
+
+use Drupal\Tests\UnitTestCase;
+use Drupal\unl_utility\UNLUtilityTrait;
+
+/**
+ * Tests strings methods in UNLUtilityTrait.
+ *
+ * @group unl_utility
+ */
+class StringTest extends UnitTestCase {
+
+  /**
+   * Tests strings methods in UNLUtilityTrait.
+   */
+  public function testStringMethods() {
+    $this->assertTrue(UNLUtilityTrait::stringStartsWith('Yaba Daba Do', 'Yaba', TRUE));
+    $this->assertFalse(UNLUtilityTrait::stringStartsWith('Yaba Daba Do', 'yaba', TRUE));
+    $this->assertFalse(UNLUtilityTrait::stringStartsWith('Yaba Daba Do', 'Do', TRUE));
+    $this->assertFalse(UNLUtilityTrait::stringStartsWith('Yaba Daba Do', 'chris', TRUE));
+
+    $this->assertTrue(UNLUtilityTrait::stringStartsWith('Yaba Daba Do', 'Yaba'));
+    $this->assertFalse(UNLUtilityTrait::stringStartsWith('Yaba Daba Do', 'yaba'));
+    $this->assertFalse(UNLUtilityTrait::stringStartsWith('Yaba Daba Do', 'Do'));
+    $this->assertFalse(UNLUtilityTrait::stringStartsWith('Yaba Daba Do', 'chris'));
+
+    $this->assertTrue(UNLUtilityTrait::stringStartsWith('Yaba Daba Do', 'Yaba', FALSE));
+    $this->assertTrue(UNLUtilityTrait::stringStartsWith('Yaba Daba Do', 'yaba', FALSE));
+    $this->assertFalse(UNLUtilityTrait::stringStartsWith('Yaba Daba Do', 'Do', FALSE));
+    $this->assertFalse(UNLUtilityTrait::stringStartsWith('Yaba Daba Do', 'chris', FALSE));
+
+    $this->assertTrue(UNLUtilityTrait::stringEndsWith('Yaba Daba Do', 'Do', TRUE));
+    $this->assertFalse(UNLUtilityTrait::stringEndsWith('Yaba Daba Do', 'do', TRUE));
+    $this->assertFalse(UNLUtilityTrait::stringEndsWith('Yaba Daba Do', 'Yaba', TRUE));
+    $this->assertFalse(UNLUtilityTrait::stringEndsWith('Yaba Daba Do', 'chris', TRUE));
+
+    $this->assertTrue(UNLUtilityTrait::stringEndsWith('Yaba Daba Do', 'Do'));
+    $this->assertFalse(UNLUtilityTrait::stringEndsWith('Yaba Daba Do', 'do'));
+    $this->assertFalse(UNLUtilityTrait::stringEndsWith('Yaba Daba Do', 'Yaba'));
+    $this->assertFalse(UNLUtilityTrait::stringEndsWith('Yaba Daba Do', 'chris'));
+
+    $this->assertTrue(UNLUtilityTrait::stringEndsWith('Yaba Daba Do', 'Do', FALSE));
+    $this->assertTrue(UNLUtilityTrait::stringEndsWith('Yaba Daba Do', 'do', FALSE));
+    $this->assertFalse(UNLUtilityTrait::stringEndsWith('Yaba Daba Do', 'Yaba', FALSE));
+    $this->assertFalse(UNLUtilityTrait::stringEndsWith('Yaba Daba Do', 'chris', FALSE));
+
+    $this->assertTrue(UNLUtilityTrait::stringContains('Yaba Daba Do', 'Do', TRUE));
+    $this->assertFalse(UNLUtilityTrait::stringContains('Yaba Daba Do', 'do', TRUE));
+    $this->assertTrue(UNLUtilityTrait::stringContains('Yaba Daba Do', 'Yaba', TRUE));
+    $this->assertFalse(UNLUtilityTrait::stringContains('Yaba Daba Do', 'chris', TRUE));
+
+    $this->assertTrue(UNLUtilityTrait::stringContains('Yaba Daba Do', 'Do'));
+    $this->assertFalse(UNLUtilityTrait::stringContains('Yaba Daba Do', 'do'));
+    $this->assertTrue(UNLUtilityTrait::stringContains('Yaba Daba Do', 'Yaba'));
+    $this->assertFalse(UNLUtilityTrait::stringContains('Yaba Daba Do', 'chris'));
+
+    $this->assertTrue(UNLUtilityTrait::stringContains('Yaba Daba Do', 'Do', FALSE));
+    $this->assertTrue(UNLUtilityTrait::stringContains('Yaba Daba Do', 'do', FALSE));
+    $this->assertTrue(UNLUtilityTrait::stringContains('Yaba Daba Do', 'Yaba', FALSE));
+    $this->assertFalse(UNLUtilityTrait::stringContains('Yaba Daba Do', 'chris', FALSE));
+  }
+
+}


### PR DESCRIPTION
This issue seeks to add the following methods to `Drupal\unl_utility\UNLUtilityTrait`:

- `stringStartsWith()`
- `stringEndsWith()`
- `stringContains()`