### PR TITLE
Provide Default Development Settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,9 @@ Navigate to `http://example.unl.edu/project-herbie/web` in your browser.
 See [Installing Drupal 8](https://www.drupal.org/docs/8/install)
 
 When asked to select an Installation Profile, select "Use existing configuration"
+
+### Config Split
+
+This project uses Config Split to manage configuration among production, stage, and development. Certain modules, such as Twig Xdebug and Config Inspector are only enabled on development.
+
+In the development config split, a number of settings are enabled, disabled, or modified: Caching is disabled; Twig caching is disabled and Twig autoloading is enabled; debug cacheability headers are enabled; CSS and JS aggregation is disabled; and file permission hardening is disabled.  See /profiles/herbie/includes/settings.php.inc for more details. These settings can be overridden in settings.local.php.

--- a/web/profiles/herbie/includes/development.services.yml
+++ b/web/profiles/herbie/includes/development.services.yml
@@ -1,0 +1,12 @@
+# Local development services.
+#
+# To activate this feature, follow the instructions at the top of the
+# 'example.settings.local.php' file, which sits next to this file.
+parameters:
+  http.response.debug_cacheability_headers: true
+  twig.config:
+    debug: true
+    auto_reload: true
+services:
+  cache.backend.null:
+    class: Drupal\Core\Cache\NullBackendFactory

--- a/web/profiles/herbie/includes/development.services.yml
+++ b/web/profiles/herbie/includes/development.services.yml
@@ -1,7 +1,4 @@
 # Local development services.
-#
-# To activate this feature, follow the instructions at the top of the
-# 'example.settings.local.php' file, which sits next to this file.
 parameters:
   http.response.debug_cacheability_headers: true
   twig.config:
@@ -10,3 +7,4 @@ parameters:
 services:
   cache.backend.null:
     class: Drupal\Core\Cache\NullBackendFactory
+

--- a/web/profiles/herbie/includes/settings.php.inc
+++ b/web/profiles/herbie/includes/settings.php.inc
@@ -22,10 +22,30 @@ elseif ($environment == 'stage') {
   $config['config_split.config_split.development']['status'] = FALSE;
   $settings['file_temp_path'] = '/var/www/unl.edu/tmp/project-herbie';
 }
+// If not production or stage, then assumed to be development.
 else {
   $config['config_split.config_split.production']['status'] = FALSE;
   $config['config_split.config_split.stage']['status'] = FALSE;
   $config['config_split.config_split.development']['status'] = TRUE;
+
+  /*
+   * Assertions.
+   *
+   * The Drupal project primarily uses runtime assertions to enforce the
+   * expectations of the API by failing when incorrect calls are made by code
+   * under development.
+   *
+   * @see http://php.net/assert
+   * @see https://www.drupal.org/node/2492225
+   *
+   * If you are using PHP 7.0 it is strongly recommended that you set
+   * zend.assertions=1 in the PHP.ini file (It cannot be changed from .htaccess
+   * or runtime) on development machines and to 0 in production.
+   *
+   * @see https://wiki.php.net/rfc/expectations
+   */
+  assert_options(ASSERT_ACTIVE, TRUE);
+  \Drupal\Component\Assertion\Handle::register();
 
   // This will prevent Drupal from setting read-only permissions on sites/default.
   $settings['skip_permissions_hardening'] = TRUE;
@@ -33,6 +53,21 @@ else {
   // This will ensure the site can only be accessed through the intended host
   // names. Additional host patterns can be added for custom configurations.
   $settings['trusted_host_patterns'] = ['.*'];
+
+  // Enable Herbie development.services.yml.
+  // Provides cache.backend.null.
+  // Disables Twig caching and enables Twig autoload.
+  // Adds debug cacheability headers.
+  $settings['container_yamls'][] = DRUPAL_ROOT . '/profiles/herbie/includes/development.services.yml';
+
+  // Disable CSS and JS preprocessing.
+  $config['system.performance']['css']['preprocess'] = FALSE;
+  $config['system.performance']['js']['preprocess'] = FALSE;
+
+  // Disable render, dynamic page, and page cache.
+  $settings['cache']['bins']['render'] = 'cache.backend.null';
+  $settings['cache']['bins']['dynamic_page_cache'] = 'cache.backend.null';
+  $settings['cache']['bins']['page'] = 'cache.backend.null';
 
   // For local development, the temp directory should be set
   // in settings.local.php.


### PR DESCRIPTION
This issue seeks to take the various development settings from example.settings.local.php and from [Disable Drupal 8 caching during development](https://www.drupal.org/node/2598914) and incorporate them into the Herbie profile:

- Registers development assertion behavior per https://www.drupal.org/node/2492225
- Disables JS and CSS aggregation
- Disables render, dynamic page, and page cache
- Disables Twig cache and enable Twig autoloading
- Add debug cacheability headers
