### PR TITLE
Configure Layout Builder Modal to autoresize modals

### DIFF
--- a/config/sync/layout_builder_modal.settings.yml
+++ b/config/sync/layout_builder_modal.settings.yml
@@ -2,5 +2,5 @@ modal_width: 768
 modal_height: auto
 _core:
   default_config_hash: FBCBcxmprJV8vz8zOEBGIVnH-Tsfbe_pA9tFO8O9Z5I
-modal_autoresize: false
+modal_autoresize: true
 theme_display: default_theme


### PR DESCRIPTION
Currently, if a modal is too tall, it gets clipped vertically, which may make it impossible to click on a submit button at the bottom of the modal. This issue seeks to modify the Layout Builder Modal configuration to autoresize modals.