### PR TITLE
unl_five_herbie_preprocess_region() causes a fatal error on node revision pages

### DIFF
--- a/web/themes/custom/unl_five_herbie/unl_five_herbie.theme
+++ b/web/themes/custom/unl_five_herbie/unl_five_herbie.theme
@@ -5,6 +5,7 @@
  * Contains theme functions for unl_five_herbie.
  */
 
+use Drupal\node\NodeInterface;
 use Drupal\views\Views;
 
 /**
@@ -13,8 +14,8 @@ use Drupal\views\Views;
 function unl_five_herbie_preprocess_region(&$variables) {
   // Hide the hero region page title on Person nodes.
   $current_route = \Drupal::routeMatch();
-  $node = $current_route->getParameters()->get('node');
-  if ($node) {
+  $node = $current_route->getParameter('node');
+  if ($node instanceof NodeInterface) {
     $bundle = $node->bundle();
 
     switch ($bundle) {
@@ -27,8 +28,8 @@ function unl_five_herbie_preprocess_region(&$variables) {
   // Add the Hero field (s_n_hero) to the hero region template, region--hero.html.twig.
   if ($variables['region'] == 'hero') {
     $current_route = \Drupal::routeMatch();
-    $node = $current_route->getParameters()->get('node');
-    if ($node && $node->hasField('s_n_hero') && !$node->get('s_n_hero')->isEmpty()) {
+    $node = $current_route->getParameter('node');
+    if ($node instanceof NodeInterface && $node->hasField('s_n_hero') && !$node->get('s_n_hero')->isEmpty()) {
       $variables['s_n_hero'] = $node->get('s_n_hero')->view(['label' => 'hidden', 'type' => 'entity_reference_entity_view']);
     }
   }


### PR DESCRIPTION
When attempting to view a node revision, the following error is encountered:

`Error: Call to a member function bundle() on string in unl_five_herbie_preprocess_region() (line 18 of /var/www/html/web/themes/custom/unl_five_herbie/unl_five_herbie.theme)`

Steps to reproduce:

1. Create a node (node/add)
1. Edit the node and create a revision (node/[nid]/edit)
1. Attempt to view the revision (node/[nid]/revisions/[vid]/view)

When `\Drupal::routeMatch()->getParameter('node')` is called on a node view page, it returns a node object. When it's called on a revision view page, it returns the node id. The code attempts to execute the bundle() method on the return value regardless. In the case of a revision page, this causes the above fatal error.

Once that issue is resolves, there is a second issue. Same steps to reproduce, but different error:

`Error: Call to a member function hasField() on string in unl_five_herbie_preprocess_region() (line 31 of /var/www/html/web/themes/custom/unl_five_herbie/unl_five_herbie.theme)`

Again, the $node variable needs to be checked to determine if it's a node object before calling methods on it.