### PR TITLE
Modify UnlScriptHandler.php to use project's grunt-cli when globally unavailable

### DIFF
--- a/scripts/composer/UnlScriptHandler.php
+++ b/scripts/composer/UnlScriptHandler.php
@@ -45,15 +45,17 @@ class UnlScriptHandler {
     $io->write("Installing Node project at " . $composerRoot . "/vendor/unl/wdntemplates");
     exec("cd $composerRoot/vendor/unl/wdntemplates; npm install");
 
-    // Check if Grunt CLI is installed.
-    if (empty(exec("which grunt"))) {
-      $io->write("Grunt CLI is not installed. Run 'npm install -g grunt-cli'");
-      return;
-    }
-
     // Run Grunt default task.
     $io->write("Running Grunt default task at " . $composerRoot . "/vendor/unl/wdntemplates");
-    exec("cd $composerRoot/vendor/unl/wdntemplates; grunt");
+
+    // Check if Grunt CLI is installed globally.
+    if (!empty(exec("which grunt"))) {
+      system("cd $composerRoot/vendor/unl/wdntemplates; grunt");
+    }
+    else {
+      $io->write("Grunt CLI is not installed globally. Executing from NPM binary.");
+      system("cd $composerRoot/vendor/unl/wdntemplates; ./node_modules/grunt-cli/bin/grunt");
+    }
   }
 
   /**


### PR DESCRIPTION
There are instances where grunt-cli may not be installed globally (e.g. a development web server). The unl/wdntemplates project recently added grunt-cli as a dev dependency (unl/wdntemplates#1437 and unl/wdntemplates#1438).

This PR seeks to add a fallback in UnlScriptHandler.php to use the project's grunt-cli package in the event grunt-cli is not installed globally.