### PR TITLE
Modify UnlScriptHandler.php to use NPM's "ci" command instead of "install"

### DIFF
--- a/scripts/composer/UnlScriptHandler.php
+++ b/scripts/composer/UnlScriptHandler.php
@@ -43,7 +43,7 @@ class UnlScriptHandler {
 
     // Install NPM project.
     $io->write("Installing Node project at " . $composerRoot . "/vendor/unl/wdntemplates");
-    exec("cd $composerRoot/vendor/unl/wdntemplates; npm install");
+    system("cd $composerRoot/vendor/unl/wdntemplates; npm ci");
 
     // Check if Grunt CLI is installed.
     if (empty(exec("which grunt"))) {


### PR DESCRIPTION
This PR seeks to modify `UnlScriptHandler.php::deployWdn()` by swapping out `npm install` with `npm ci`, which will then respect the lock file.

It also replaces `exec()` command with `system()` to render the output.