### PR TITLE
'core.entity_view_display.node.builder_page.default' Overridden on New Install

### DIFF
--- a/config/sync/core.entity_view_display.node.builder_page.default.yml
+++ b/config/sync/core.entity_view_display.node.builder_page.default.yml
@@ -29,6 +29,9 @@ third_party_settings:
           section_package: ''
           section_classes: {  }
           block_margin: ''
+          section_element_id: ''
+          column_classes:
+            col_1: {  }
         components:
           df00a0ac-af4b-4bda-90a2-ec1fd6694af1:
             uuid: df00a0ac-af4b-4bda-90a2-ec1fd6694af1


### PR DESCRIPTION
On a new install, the 'core.entity_view_display.node.builder_page.default' config object is overridden:

![image](https://user-images.githubusercontent.com/1521132/94458140-277c6100-017b-11eb-8e7c-c9d820ff6d57.png)
