### PR TITLE
Change case of MediaHub in oEmbed configuration

### DIFF
--- a/config/sync/media.type.remote_video.yml
+++ b/config/sync/media.type.remote_video.yml
@@ -11,7 +11,7 @@ new_revision: false
 source_configuration:
   thumbnails_directory: 'public://oembed_thumbnails'
   providers:
-    - 'UNL MediaHub'
+    - 'UNL Mediahub'
   source_field: field_media_oembed_video
 field_map:
   type: m_rv_resource_type

--- a/config/sync/oembed_providers.provider.unl_mediahub.yml
+++ b/config/sync/oembed_providers.provider.unl_mediahub.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: unl_mediahub
-label: 'UNL MediaHub'
+label: 'UNL Mediahub'
 provider_url: 'https://mediahub.unl.edu'
 endpoints:
   -

--- a/config/sync/oembed_providers.settings.yml
+++ b/config/sync/oembed_providers.settings.yml
@@ -1,5 +1,5 @@
 allowed_providers:
-  - 'UNL MediaHub'
+  - 'UNL Mediahub'
 external_fetch: false
 _core:
   default_config_hash: lgWtCY9jfjkig9RkOgXl1JO2lGljsH4yqnQeKK1VpoA


### PR DESCRIPTION
In Project Herbie config, the UNL MediaHub provider uses correct capitalization; however, MediaHub does not in its oEmbed responses; rather, "UNL Mediahub" instead of "UNL MediaHub". Drupal matches oEmbed providers in a case sensitive manner. (See https://www.drupal.org/project/drupal/issues/3062430.) As a result, users are presently unable to add oEmbed content from UNL MediaHub.

This PR seeks to change the MediaHub label to match what's being returned from MediaHub in its oEmbed responses.