### PR TITLE
Secondary nav not rendering outside of menu tree

### DIFF
--- a/config/sync/block.block.unl_five_herbie_mainnavigation.yml
+++ b/config/sync/block.block.unl_five_herbie_mainnavigation.yml
@@ -21,5 +21,5 @@ settings:
   label_display: '0'
   level: 1
   depth: 2
-  expand_all_items: false
+  expand_all_items: true
 visibility: {  }


### PR DESCRIPTION
Per Aaron:

> When you’re on a page in one section of the nav (“HMED Home” or “Academics”), you can’t see the secondary navigation for the other sections of the navigation