### PR TITLE
Add "Person List" block

### DIFF
--- a/config/sync/core.entity_view_display.node.builder_page.default.yml
+++ b/config/sync/core.entity_view_display.node.builder_page.default.yml
@@ -64,6 +64,7 @@ third_party_settings:
             'Aggregated Content': {  }
             'Chaos Tools': {  }
             'Content fields': {  }
+            'Curated Lists': {  }
             'Custom block types':
               - card
               - card_circle_image
@@ -85,9 +86,10 @@ third_party_settings:
           all_regions:
             'Aggregated Content':
               - unl_recent_news
-            'Chaos Tools': {  }
             'Content fields':
               - 'field_block:node:builder_page:body'
+            'Curated Lists':
+              - unl_person_list
             'Custom block types':
               - accordion
               - card
@@ -95,7 +97,6 @@ third_party_settings:
               - content
               - events_band
               - html_code
-            Forms: {  }
             'Inline blocks':
               - 'inline_block:accordion'
               - 'inline_block:card'
@@ -115,6 +116,7 @@ third_party_settings:
               - unl_recent_news
             'Chaos Tools': {  }
             'Content fields': {  }
+            'Curated Lists': {  }
             'Custom block types':
               - card
               - card_circle_image
@@ -139,6 +141,7 @@ third_party_settings:
             'Chaos Tools': {  }
             'Content fields':
               - 'field_block:node:builder_page:body'
+            'Curated Lists': {  }
             'Custom block types':
               - accordion
               - card
@@ -156,7 +159,21 @@ third_party_settings:
             System: {  }
             User: {  }
             core: {  }
-    allowed_block_categories: {  }
+      blacklisted_blocks: {  }
+    allowed_block_categories:
+      - 'Aggregated Content'
+      - 'Chaos Tools'
+      - 'Content fields'
+      - 'Curated Lists'
+      - 'Custom block types'
+      - Forms
+      - 'Inline blocks'
+      - 'Lists (Views)'
+      - Menus
+      - System
+      - User
+      - Webform
+      - core
     entity_view_mode_restriction:
       whitelisted_blocks: {  }
       blacklisted_blocks: {  }

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -100,6 +100,7 @@ module:
   unl_menu: 0
   unl_news: 0
   unl_pathauto: 0
+  unl_person: 0
   unl_trailing_slash: 0
   unl_twig: 0
   unl_user: 0

--- a/web/modules/custom/unl_person/src/Plugin/Block/PersonBlock.php
+++ b/web/modules/custom/unl_person/src/Plugin/Block/PersonBlock.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Drupal\unl_person\Plugin\Block;
+
+use Drupal\Core\Block\BlockBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Template\Attribute;
+
+/**
+ * Provides a Person List block.
+ *
+ * @Block(
+ *   id = "unl_person_list",
+ *   admin_label = @Translation("Person"),
+ *   category = @Translation("Curated Lists"),
+ * )
+ */
+class PersonBlock extends BlockBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration() {
+    return [
+      'persons' => [],
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function blockForm($form, FormStateInterface $form_state) {
+    $person_nodes = \Drupal::entityTypeManager()->getStorage('node')
+      ->loadByProperties(['type' => 'person', 'status' => 1]);
+    $options = [];
+    foreach ($person_nodes as $node) {
+      $options[$node->id()] = $node->label();
+    }
+
+    $form['persons'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Persons to display'),
+      '#required' => TRUE,
+      '#multiple' => TRUE,
+      '#default_value' => $this->configuration['persons'],
+      '#options' => $options,
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function blockSubmit($form, FormStateInterface $form_state) {
+    $this->configuration['persons'] = $form_state
+      ->getValue('persons');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build() {
+    return [
+      '#theme' => 'unl_person_person_list',
+      '#attributes' => new Attribute(
+        [
+          'class' => [
+            'unl-person-list',
+          ],
+        ],
+      ),
+      '#nodes' => $this->configuration['persons'],
+    ];
+  }
+}

--- a/web/modules/custom/unl_person/templates/unl-person-person-list.html.twig
+++ b/web/modules/custom/unl_person/templates/unl-person-person-list.html.twig
@@ -1,0 +1,5 @@
+<div{{ attributes }}>
+  {% for nid in nodes %}
+    {{ drupal_entity('node', nid, 'teaser') }}
+  {% endfor %}
+</div>

--- a/web/modules/custom/unl_person/unl_person.info.yml
+++ b/web/modules/custom/unl_person/unl_person.info.yml
@@ -1,0 +1,11 @@
+name: 'UNL Person'
+description: 'Provides functionality for Persons'
+package: UNL
+
+type: module
+core_version_requirement: ^8 || ^9
+
+version: 1.x
+
+dependencies:
+- twig_tweak:twig_tweak

--- a/web/modules/custom/unl_person/unl_person.module
+++ b/web/modules/custom/unl_person/unl_person.module
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * Implements hook_theme().
+ */
+function unl_person_theme($existing, $type, $theme, $path) {
+  return [
+    'unl_person_person_list' => [
+      'variables' => [
+        'attributes' => [],
+        'nodes' => [],
+      ],
+    ],
+  ];
+}

--- a/web/themes/custom/unl_five_herbie/templates/block/unl-person-person-list.html.twig
+++ b/web/themes/custom/unl_five_herbie/templates/block/unl-person-person-list.html.twig
@@ -1,0 +1,13 @@
+{%
+  set attributes = attributes.addClass([
+    'dcf-grid-full',
+    'dcf-grid-halves@sm',
+    'dcf-col-gap-8',
+    'dcf-row-gap-8'
+  ])
+%}
+<div{{ attributes }}>
+  {% for nid in nodes %}
+    {{ drupal_entity('node', nid, 'teaser') }}
+  {% endfor %}
+</div>


### PR DESCRIPTION
This PR seeks to add a "Person List" block type. It programmatically defines a block type that can be placed in Layout Builder. The Twig template displays in a two-column layout.