### PR TITLE
Add 'Module Remove' service to Herbie profile

### DIFF
--- a/web/profiles/herbie/herbie.post_update.php
+++ b/web/profiles/herbie/herbie.post_update.php
@@ -6,3 +6,10 @@
 function herbie_post_update_dcf_swapout() {
   // Empty function.
 }
+
+/**
+ * Add herbie.remove_module service.
+ */
+function herbie_post_update_add_remove_module_service() {
+  // Empty function.
+}

--- a/web/profiles/herbie/herbie.services.yml
+++ b/web/profiles/herbie/herbie.services.yml
@@ -1,0 +1,4 @@
+services:
+  herbie.module_remove:
+    class: Drupal\herbie\ModuleRemove
+    arguments: ['@database', '@config.factory']

--- a/web/profiles/herbie/src/ModuleRemove.php
+++ b/web/profiles/herbie/src/ModuleRemove.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Drupal\herbie;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Database\Connection;
+
+/**
+ * Removes missing modules.
+ */
+class ModuleRemove {
+
+  /**
+   * The database connection.
+   *
+   * @var \Drupal\Core\Database\Connection
+   */
+  protected $connection;
+
+  /**
+   * The config factory.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected $configFactory;
+
+  /**
+   * Constructor.
+   *
+   * @param \Drupal\Core\Database\Connection $connection
+   *   The database connection.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The config factory.
+   */
+  public function __construct(Connection $connection, ConfigFactoryInterface $config_factory) {
+    $this->connection = $connection;
+    $this->configFactory = $config_factory;
+  }
+
+  /**
+   * Removes missing modules.
+   *
+   * @param string $module_name
+   *   The name of the missing module to be removed.
+   */
+  public function remove($module_name) {
+    // Remove from core.extensions config.
+    $extensions = $this->configFactory->getEditable('core.extension')->get();
+    unset($extensions['module'][$module_name]);
+    $this->configFactory->getEditable('core.extension')->setData($extensions);
+    $this->configFactory->getEditable('core.extension')->save();
+
+    // Clean up module's configuration (assumes correct name spacing).
+    $like = $this->connection->escapeLike($module_name . '.');
+    $config_names = $this->connection->select('config', 'c')
+      ->fields('c', ['name'])
+      ->condition('name', $like . '%', 'LIKE')
+      ->execute()
+      ->fetchAll();
+    // Delete each config using configFactory.
+    foreach ($config_names as $config_name) {
+      $this->configFactory->getEditable($config_name->name)->delete();
+    }
+
+    // Remove from key_value table.
+    $query = $this->connection->delete('key_value');
+    $query->condition('collection', 'system.schema');
+    $query->condition('name', [$module_name], 'IN');
+    $query->execute();
+  }
+
+}


### PR DESCRIPTION
From time to time, it's necessary to remove an unused module from the codebase. The "correct" way is to uninstall the module with Drupal and then to remove the code with Composer. This requires successive steps that cannot be skipped, which basically means two, consecutive releases. This creates issues. This PR seeks to add the functionality of the [Module Missing Message Fixer](https://www.drupal.org/project/module_missing_message_fixer) module but as a service (and one that also updates core.extension)