### PR TITLE
Determine how to Incorporate Webforms into Site Content Hierarchy

### DIFF
--- a/config/sync/core.entity_view_display.node.builder_page.default.yml
+++ b/config/sync/core.entity_view_display.node.builder_page.default.yml
@@ -70,7 +70,8 @@ third_party_settings:
               - card_circle_image
               - content
               - html_code
-            Forms: {  }
+            Forms:
+              - unl_webform_block
             'Inline blocks':
               - 'inline_block:card'
               - 'inline_block:card_circle_image'
@@ -97,6 +98,8 @@ third_party_settings:
               - content
               - events_band
               - html_code
+            Forms:
+              - unl_webform_block
             'Inline blocks':
               - 'inline_block:accordion'
               - 'inline_block:card'
@@ -122,7 +125,8 @@ third_party_settings:
               - card_circle_image
               - content
               - html_code
-            Forms: {  }
+            Forms:
+              - unl_webform_block
             'Inline blocks':
               - 'inline_block:card'
               - 'inline_block:card_circle_image'
@@ -148,7 +152,8 @@ third_party_settings:
               - card_circle_image
               - content
               - html_code
-            Forms: {  }
+            Forms:
+              - unl_webform_block
             'Inline blocks':
               - 'inline_block:accordion'
               - 'inline_block:card'
@@ -158,6 +163,7 @@ third_party_settings:
             Menus: {  }
             System: {  }
             User: {  }
+            Webform: {  }
             core: {  }
       blacklisted_blocks: {  }
     allowed_block_categories:

--- a/config/sync/webform.settings.yml
+++ b/config/sync/webform.settings.yml
@@ -1,31 +1,25 @@
 settings:
-  default_status: open
   default_page_base_path: /form
-  default_ajax: false
-  default_ajax_effect: fade
-  default_ajax_speed: 500
-  default_ajax_progress_type: throbber
+  default_status: open
   default_form_open_message: '<p>This form has not yet been opened to submissions.</p>'
   default_form_close_message: '<p>Sorry…This form is closed to new submissions.</p>'
   default_form_exception_message: '<p>Unable to display this webform. Please contact the site administrator.</p>'
+  default_form_confidential_message: '<p>This form is confidential. You must <a href="login-url]/logout?destination=[current-page:url:relative]">Log out</a> to submit it.</p>'
+  default_form_access_denied_message: '<p>Please login to access this form.</p>'
+  default_form_required_label: 'Indicates required field'
   default_submit_button_label: Submit
   default_reset_button_label: Reset
   default_delete_button_label: Delete
+  form_classes: "container-inline clearfix\r\nform--inline clearfix\r\nmessages messages--error\r\nmessages messages--warning\r\nmessages messages--status\r\n"
+  button_classes: ''
   default_form_submit_once: false
-  default_form_confidential_message: '<p>This form is confidential. You must <a href="login-url]/logout?destination=[current-page:url:relative]">Log out</a> to submit it.</p>'
-  default_form_access_denied_message: '<p>Please login to access this form.</p>'
   default_form_disable_back: false
   default_form_submit_back: false
   default_form_unsaved: false
-  default_form_disable_remote_addr: false
   default_form_novalidate: false
   default_form_disable_inline_errors: false
   default_form_required: false
-  default_form_required_label: 'Indicates required field'
   default_form_details_toggle: true
-  default_form_file_limit: ''
-  form_classes: "container-inline clearfix\r\nform--inline clearfix\r\nmessages messages--error\r\nmessages messages--warning\r\nmessages messages--status\r\n"
-  button_classes: ''
   default_wizard_prev_button_label: '< Previous Page'
   default_wizard_next_button_label: 'Next Page >'
   default_wizard_start_label: Start
@@ -37,13 +31,36 @@ settings:
   default_preview_label: Preview
   default_preview_title: '[webform:title]: Preview'
   default_preview_message: '<p>Please review your submission. Your submission is not complete until you press the "Submit" button!</p>'
+  preview_classes: "messages messages--error\r\nmessages messages--warning\r\nmessages messages--status\r\n"
+  default_confirmation_message: '<p>New submission added to [webform:title].</p>'
+  default_confirmation_back_label: 'Back to form'
+  confirmation_classes: "messages messages--error\r\nmessages messages--warning\r\nmessages messages--status\r\n"
+  confirmation_back_classes: "button\r\n"
+  default_share: false
+  default_share_node: false
+  default_share_theme_name: ''
+  default_ajax: true
+  default_ajax_progress_type: throbber
+  default_ajax_effect: fade
+  default_ajax_speed: 500
+  dialog_options:
+    narrow:
+      title: Narrow
+      width: 600
+    normal:
+      title: Normal
+      width: 800
+    wide:
+      title: Wide
+      width: 1000
+  dialog: false
+  default_form_disable_remote_addr: false
+  default_form_file_limit: ''
   default_draft_button_label: 'Save Draft'
   default_draft_saved_message: 'Submission saved. You may return to this form later and it will restore the current values.'
   default_draft_loaded_message: 'A partially-completed form was found. Please complete the remaining portions.'
   default_draft_pending_single_message: 'You have a pending draft for this webform. <a href="#">Load your pending draft</a>.'
   default_draft_pending_multiple_message: 'You have pending drafts for this webform. <a href="#">View your pending drafts</a>.'
-  default_confirmation_message: '<p>New submission added to [webform:title].</p>'
-  default_confirmation_back_label: 'Back to form'
   default_submission_label: '[webform_submission:submitted-to]: Submission #[webform_submission:serial]'
   default_submission_access_denied_message: 'Please login to access this submission.'
   default_submission_exception_message: 'Unable to process this submission. Please contact the site administrator.'
@@ -66,25 +83,8 @@ settings:
   default_previous_submission_message: 'You have already submitted this webform. <a href="#">View your previous submission</a>.'
   default_previous_submissions_message: 'You have already submitted this webform. <a href="#">View your previous submissions</a>.'
   default_autofill_message: 'This submission has been autofilled with your previous submission.'
-  preview_classes: "messages messages--error\r\nmessages messages--warning\r\nmessages messages--status\r\n"
-  confirmation_classes: "messages messages--error\r\nmessages messages--warning\r\nmessages messages--status\r\n"
-  confirmation_back_classes: "button\r\n"
   default_limit_total_message: 'No more submissions are permitted.'
   default_limit_user_message: 'No more submissions are permitted.'
-  default_share: false
-  default_share_node: false
-  default_share_theme_name: ''
-  dialog: false
-  dialog_options:
-    narrow:
-      title: Narrow
-      width: 600
-    normal:
-      title: Normal
-      width: 800
-    wide:
-      title: Wide
-      width: 1000
 assets:
   css: ''
   javascript: ''

--- a/web/modules/custom/unl_webform/src/Plugin/Block/WebformBlock.php
+++ b/web/modules/custom/unl_webform/src/Plugin/Block/WebformBlock.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Drupal\unl_webform\Plugin\Block;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\webform\Plugin\Block\WebformBlock as ExtendedWebformBlock;
+
+/**
+ * Provides a 'Webform' block.
+ *
+ * @Block(
+ *   id = "unl_webform_block",
+ *   admin_label = @Translation("Webform"),
+ *   category = @Translation("Forms")
+ * )
+ */
+class WebformBlock extends ExtendedWebformBlock {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function blockForm($form, FormStateInterface $form_state) {
+    $form = parent::blockForm($form, $form_state);
+    // Remove settings fieldset.
+    unset($form['settings']);
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function blockSubmit($form, FormStateInterface $form_state) {
+    $values = $form_state->getValues();
+    $this->configuration['webform_id'] = $values['webform_id'];
+  }
+
+}

--- a/web/modules/custom/unl_webform/unl_webform.module
+++ b/web/modules/custom/unl_webform/unl_webform.module
@@ -5,7 +5,39 @@
  * Modifies Webform UI to pare down options and enforce defaults.
  */
 
+use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\webform\WebformInterface;
+
+/**
+ * Implements hook_entity_create().
+ */
+function unl_webform_entity_create(EntityInterface $entity) {
+  if ($entity instanceof WebformInterface) {
+    // Alter settings for newly created Webforms.
+    $settings = $entity->getSettings();
+    // Disable "Allow users to post submissions from a dedicated URL".
+    $settings['page'] = FALSE;
+    // Set "Confirmation Type" to "inline".
+    $settings['confirmation_type'] = 'inline';
+    $settings = $entity->setSettings($settings);
+  }
+}
+
+/**
+ * Implements hook_form_alter().
+ */
+function unl_webform_form_alter(&$form, FormStateInterface &$form_state, $form_id) {
+  switch ($form_id) {
+    case 'webform_settings_form':
+      // Disable "Allow users to post submissions from a dedicated URL" field.
+      $form['page_settings']['page']['#disabled'] = TRUE;
+      break;
+    case 'webform_settings_confirmation_form':
+      $form['confirmation_type']['confirmation_type']['#disabled'] = TRUE;
+      break;
+  }
+}
 
 /**
  * Implements hook_form_FORM_ID_alter().


### PR DESCRIPTION
This issue was originally touched on in #95 with webform breadcrumbs. The issue is larger in scope, however. Webforms can have paths but not menu items, which raises the issue of how to use a webform in hierarchical site content (e.g. menus).

Options:
1. Webforms cannot be used directly as content. Instead, they are placed as blocks in Builder Pages.
2. Webforms can be used directly as content. Users will need to manually create menu items and manually define the path.

My preference is for option 1.