### PR TITLE
Create unl_system custom module; Accept affiliation_name and affiliation_url values

### DIFF
--- a/config/sync/config_ignore.settings.yml
+++ b/config/sync/config_ignore.settings.yml
@@ -29,7 +29,8 @@ ignored_config_entities:
   54: 'system.site:slogan'
   56: 'system.site:page.front'
   58: unl_breadcrumbs.settings
-  60: 'webform.webform.*'
+  60: unl_system.settings
+  62: 'webform.webform.*'
 _core:
   default_config_hash: UVH1aJ4b44UM-VdPVN7hNNuuVqfReJxwfVeDQH1Hvsk
 enable_export_filtering: '1'

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -98,6 +98,7 @@ module:
   unl_news: 0
   unl_pathauto: 0
   unl_person: 0
+  unl_system: 0
   unl_trailing_slash: 0
   unl_twig: 0
   unl_user: 0

--- a/web/modules/custom/unl_system/config/install/unl_system.settings.yml
+++ b/web/modules/custom/unl_system/config/install/unl_system.settings.yml
@@ -1,0 +1,4 @@
+allowed_themes: all
+allowed_theme_list: {  }
+default_selected_themes: {  }
+codemirror_config: ''

--- a/web/modules/custom/unl_system/config/schema/unl_system.schema.yml
+++ b/web/modules/custom/unl_system/config/schema/unl_system.schema.yml
@@ -1,0 +1,10 @@
+unl_system.settings:
+  type: config_object
+  label: 'UNL System settings'
+  mapping:
+    affiliation_name:
+      type: string
+      label: 'Affiliation Name'
+    affiliation_url:
+      type: string
+      label: 'Affiliation URL'

--- a/web/modules/custom/unl_system/unl_system.info.yml
+++ b/web/modules/custom/unl_system/unl_system.info.yml
@@ -1,0 +1,8 @@
+name: 'UNL System'
+description: 'System-wide customizations for UNLcms'
+package: UNL
+
+type: module
+core_version_requirement: ^8 || ^9
+
+version: 1.x

--- a/web/modules/custom/unl_system/unl_system.module
+++ b/web/modules/custom/unl_system/unl_system.module
@@ -1,0 +1,94 @@
+<?php
+
+/**
+ * @file
+ * The module file for UNL System.
+ */
+
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Implements hook_form_alter().
+ */
+function unl_system_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  if ($form_id == 'system_site_information_settings') {
+    /** @var \Drupal\Core\Config\ConfigFactoryInterface */
+    $config_factory = \Drupal::service('config.factory');
+    $config = $config_factory->get('unl_system.settings');
+
+    $form['site_information']['#weight'] = -10;
+
+    $form['unl_affiliation'] = [
+      '#type' => 'details',
+      '#title' => 'UNL Affiliation',
+      '#open' => TRUE,
+      '#weight' => -9,
+    ];
+    $form['unl_affiliation']['affiliation_name'] = [
+      '#type' => 'textfield',
+      '#title' => t('Affiliation Name'),
+      '#default_value' => $config->get('affiliation_name'),
+    ];
+    $form['unl_affiliation']['affiliation_url'] = [
+      '#type' => 'url',
+      '#title' => t('Affiliation URL'),
+      '#default_value' => $config->get('affiliation_url'),
+    ];
+    $form['#validate'][] = '_unl_system_system_site_information_settings_validate';
+    $form['#submit'][] = '_unl_system_system_site_information_settings_submit';
+  }
+
+}
+
+/**
+ * Validates system_site_information_settings form.
+ *
+ * @param array $form
+ *   A array describing the form.
+ * @param Drupal\Core\Form\FormStateInterface $form_state
+ *   The current state of the form.
+ */
+function _unl_system_system_site_information_settings_validate(array $form, FormStateInterface $form_state) {
+  $values = $form_state->getValues();
+
+  if ($values['affiliation_name'] && empty($values['affiliation_url'])) {
+    $form_state->setErrorByName('affiliation_url', 'Affiliation URL is required if Affiliation Name is defined.');
+  }
+  if (empty($values['affiliation_name']) && $values['affiliation_url']) {
+    $form_state->setErrorByName('affiliation_name', 'Affiliation Name is required if Affiliation URL is defined.');
+  }
+}
+
+/**
+ * Submits system_site_information_settings form.
+ *
+ * @param array $form
+ *   A array describing the form.
+ * @param Drupal\Core\Form\FormStateInterface $form_state
+ *   The current state of the form.
+ */
+function _unl_system_system_site_information_settings_submit(array $form, FormStateInterface $form_state) {
+  $values = $form_state->getValues();
+
+  /** @var \Drupal\Core\Config\ConfigFactoryInterface */
+  $config_factory = \Drupal::service('config.factory');
+
+  /** @var \Drupal\Core\Config\Config */
+  $config = $config_factory->getEditable('unl_system.settings');
+  $config->set('affiliation_name', $values['affiliation_name']);
+  $config->set('affiliation_url', $values['affiliation_url']);
+  $config->save();
+}
+
+/**
+ * Implements hook_preprocess_block().
+ */
+function unl_system_preprocess_block(&$vars) {
+  if ($vars['plugin_id'] == 'system_branding_block') {
+    $config_factory = \Drupal::service('config.factory');
+    $config = $config_factory->get('unl_system.settings');
+
+    $vars['affiliation_name'] = $config->get('affiliation_name');
+    $vars['affiliation_url'] = $config->get('affiliation_url');
+  }
+}


### PR DESCRIPTION
The _unl_five_ theme now supports `affiliation_name` and `affiliation_url` variable values in the system branding block. This PR seeks to create a unl_system module to collect those as data on the basic site settings page and to make them available using `hook_preprocess_block()`.