### PR TITLE
Remove hard-coded lazy-loading classes from image.html.twig

### DIFF
--- a/web/themes/custom/unl_five_herbie/templates/field/image.html.twig
+++ b/web/themes/custom/unl_five_herbie/templates/field/image.html.twig
@@ -15,10 +15,10 @@
 
 {# Loop through potential fields and add classes. #}
 {% if field_name == 'b_card_image' %}
-  {% set attributes = attributes.addClass(['dcf-d-block', 'dcf-lazy-img', 'dcf-fade-in']) %}
+  {% set attributes = attributes.addClass(['dcf-d-block']) %}
 {% endif %}
 {% if field_name == 'b_cdcir_image' %}
-  {% set attributes = attributes.addClass(['dcf-d-block', 'dcf-lazy-img', 'dcf-fade-in', 'dcf-h-100%', 'dcf-w-100%', 'dcf-circle', 'dcf-ratio-child']) %}
+  {% set attributes = attributes.addClass(['dcf-d-block', 'dcf-h-100%', 'dcf-w-100%', 'dcf-circle', 'dcf-ratio-child']) %}
 {% endif %}
 
 {# Regardless of the field, remove the data-field-name attribute. #}


### PR DESCRIPTION
The image.html.twig file contains hard-coded DCF lazy-loading classes. DCF lazy loading is not yet enabled for this distribution. As a result, images with these classes will be hidden and will not display to end users. This PR seeks to remove DCF lazy-loading classes from image.html.twig.