### PR TITLE
Update Text Formats

### DIFF
--- a/config/sync/editor.editor.block_body.yml
+++ b/config/sync/editor.editor.block_body.yml
@@ -48,7 +48,7 @@ settings:
     language:
       language_list: un
     stylescombo:
-      styles: "a.dcf-btn.dcf-btn-primary|Primary Button\r\na.dcf-btn.dcf-btn-secondary|Secondary Button\r\na.dcf-btn.dcf-btn-tertiary|Tertiary Button\r\na.dcf-btn.dcf-btn-inverse-primary|Inverse Primary Button\r\na.dcf-btn.dcf-btn-inverse-secondary|Inverse Secondary Button\r\na.dcf-btn.dcf-btn-inverse-tertiary|Inverse Tertiary Button"
+      styles: "a.dcf-btn.dcf-btn-primary|Primary Button\r\na.dcf-btn.dcf-btn-secondary|Secondary Button\r\na.dcf-btn.dcf-btn-tertiary|Tertiary Button\r\na.dcf-btn.dcf-btn-inverse-primary|Inverse Primary Button\r\na.dcf-btn.dcf-btn-inverse-secondary|Inverse Secondary Button\r\na.dcf-btn.dcf-btn-inverse-tertiary|Inverse Tertiary Button\r\np.dcf-txt-xs|Extra small\r\np.dcf-txt-sm|Small\r\np.dcf-txt-md|Medium\r\np.dcf-txt-lg|Large\r\np.unl-font-serif|Serif"
     customconfig:
       ckeditor_custom_config: 'forcePasteAsPlainText = true'
     dcf_base:

--- a/config/sync/editor.editor.block_body.yml
+++ b/config/sync/editor.editor.block_body.yml
@@ -15,6 +15,7 @@ settings:
         -
           name: Formatting
           items:
+            - Format
             - Bold
             - Italic
             - Strike

--- a/config/sync/editor.editor.block_body.yml
+++ b/config/sync/editor.editor.block_body.yml
@@ -33,6 +33,10 @@ settings:
             - BulletedList
             - NumberedList
         -
+          name: Media
+          items:
+            - DrupalMediaLibrary
+        -
           name: Tools
           items:
             - SpecialChar

--- a/config/sync/editor.editor.standard.yml
+++ b/config/sync/editor.editor.standard.yml
@@ -50,7 +50,7 @@ settings:
     language:
       language_list: un
     stylescombo:
-      styles: "a.dcf-btn.dcf-btn-primary|Primary Button\r\na.dcf-btn.dcf-btn-secondary|Secondary Button\r\na.dcf-btn.dcf-btn-tertiary|Tertiary Button\r\na.dcf-btn.dcf-btn-inverse-primary|Inverse Primary Button\r\na.dcf-btn.dcf-btn-inverse-secondary|Inverse Secondary Button\r\na.dcf-btn.dcf-btn-inverse-tertiary|Inverse Tertiary Button"
+      styles: "a.dcf-btn.dcf-btn-primary|Primary Button\r\na.dcf-btn.dcf-btn-secondary|Secondary Button\r\na.dcf-btn.dcf-btn-tertiary|Tertiary Button\r\na.dcf-btn.dcf-btn-inverse-primary|Inverse Primary Button\r\na.dcf-btn.dcf-btn-inverse-secondary|Inverse Secondary Button\r\na.dcf-btn.dcf-btn-inverse-tertiary|Inverse Tertiary Button\r\np.dcf-txt-xs|Extra small\r\np.dcf-txt-sm|Small\r\np.dcf-txt-md|Medium\r\np.dcf-txt-lg|Large\r\np.unl-font-serif|Serif"
     customconfig:
       ckeditor_custom_config: "forcePasteAsPlainText = true\r\nremovePlugins = \"showborders\""
     dcf_base:

--- a/config/sync/filter.format.block_body.yml
+++ b/config/sync/filter.format.block_body.yml
@@ -35,7 +35,7 @@ filters:
     status: true
     weight: -48
     settings:
-      allowed_html: '<p> <br> <em> <strong> <ul type> <ol start type> <li> <h3 id> <s> <sup> <sub> <a href hreflang data-entity-substitution data-entity-type data-entity-uuid title target class="dcf-btn dcf-btn-primary dcf-btn-secondary dcf-btn-tertiary dcf-btn-inverse-primary dcf-btn-inverse-secondary dcf-btn-inverse-tertiary">'
+      allowed_html: '<p> <br> <em> <strong> <ul type> <ol start type> <li> <h2 id> <h3 id> <s> <sup> <sub> <a href hreflang data-entity-substitution data-entity-type data-entity-uuid title target class="dcf-btn dcf-btn-primary dcf-btn-secondary dcf-btn-tertiary dcf-btn-inverse-primary dcf-btn-inverse-secondary dcf-btn-inverse-tertiary">'
       filter_html_help: true
       filter_html_nofollow: false
   filter_autop:

--- a/config/sync/filter.format.block_body.yml
+++ b/config/sync/filter.format.block_body.yml
@@ -2,6 +2,10 @@ uuid: 6983055e-946a-429b-b977-4d0e17c8cd6a
 langcode: en
 status: true
 dependencies:
+  config:
+    - core.entity_view_mode.media.narrow
+    - core.entity_view_mode.media.remote_video
+    - core.entity_view_mode.media.wide
   module:
     - editor
     - linkit
@@ -35,7 +39,7 @@ filters:
     status: true
     weight: -48
     settings:
-      allowed_html: '<p> <br> <em> <strong> <ul type> <ol start type> <li> <h2 id> <h3 id> <s> <sup> <sub> <a href hreflang data-entity-substitution data-entity-type data-entity-uuid title target class="dcf-btn dcf-btn-primary dcf-btn-secondary dcf-btn-tertiary dcf-btn-inverse-primary dcf-btn-inverse-secondary dcf-btn-inverse-tertiary">'
+      allowed_html: '<p> <br> <em> <strong> <ul type> <ol start type> <li> <h2 id> <h3 id> <s> <sup> <sub> <a href hreflang data-entity-substitution data-entity-type data-entity-uuid title target class="dcf-btn dcf-btn-primary dcf-btn-secondary dcf-btn-tertiary dcf-btn-inverse-primary dcf-btn-inverse-secondary dcf-btn-inverse-tertiary"> <drupal-media data-entity-type data-entity-uuid data-view-mode data-align data-caption alt title>'
       filter_html_help: true
       filter_html_nofollow: false
   filter_autop:
@@ -47,13 +51,13 @@ filters:
   filter_align:
     id: filter_align
     provider: filter
-    status: false
+    status: true
     weight: -45
     settings: {  }
   filter_caption:
     id: filter_caption
     provider: filter
-    status: false
+    status: true
     weight: -44
     settings: {  }
   filter_htmlcorrector:
@@ -78,19 +82,21 @@ filters:
   media_embed:
     id: media_embed
     provider: media
-    status: false
+    status: true
     weight: 100
     settings:
       default_view_mode: default
-      allowed_media_types: {  }
+      allowed_media_types:
+        image: image
+        remote_video: remote_video
       allowed_view_modes: {  }
       bundle_view_modes:
-        file:
-          default_view_mode: default
-          allowed_view_modes: {  }
         image:
-          default_view_mode: default
-          allowed_view_modes: {  }
+          default_view_mode: narrow
+          allowed_view_modes:
+            narrow: narrow
+            wide: wide
         remote_video:
-          default_view_mode: default
-          allowed_view_modes: {  }
+          default_view_mode: remote_video
+          allowed_view_modes:
+            remote_video: remote_video

--- a/config/sync/filter.format.block_body.yml
+++ b/config/sync/filter.format.block_body.yml
@@ -39,7 +39,7 @@ filters:
     status: true
     weight: -48
     settings:
-      allowed_html: '<p> <br> <em> <strong> <ul type> <ol start type> <li> <h2 id> <h3 id> <s> <sup> <sub> <a href hreflang data-entity-substitution data-entity-type data-entity-uuid title target class="dcf-btn dcf-btn-primary dcf-btn-secondary dcf-btn-tertiary dcf-btn-inverse-primary dcf-btn-inverse-secondary dcf-btn-inverse-tertiary"> <drupal-media data-entity-type data-entity-uuid data-view-mode data-align data-caption alt title>'
+      allowed_html: '<br> <em> <strong> <ul type> <ol start type> <li> <h2 id> <h3 id> <s> <sup> <sub> <a href hreflang data-entity-substitution data-entity-type data-entity-uuid title target class="dcf-btn dcf-btn-primary dcf-btn-secondary dcf-btn-tertiary dcf-btn-inverse-primary dcf-btn-inverse-secondary dcf-btn-inverse-tertiary"> <drupal-media data-entity-type data-entity-uuid data-view-mode data-align data-caption alt title> <p class>'
       filter_html_help: true
       filter_html_nofollow: false
   filter_autop:

--- a/config/sync/filter.format.standard.yml
+++ b/config/sync/filter.format.standard.yml
@@ -39,7 +39,7 @@ filters:
     status: true
     weight: -48
     settings:
-      allowed_html: '<p> <br> <a href hreflang data-entity-type data-entity-uuid data-entity-substitution title target class="dcf-btn dcf-btn-primary dcf-btn-secondary dcf-btn-tertiary dcf-btn-inverse-primary dcf-btn-inverse-secondary dcf-btn-inverse-tertiary"> <em> <strong> <cite> <blockquote cite> <ul type> <ol start type> <li> <h2 id> <h3 id> <s> <sup> <sub> <table class> <caption> <tbody> <thead> <tfoot> <th> <td> <tr> <drupal-media data-entity-type data-entity-uuid data-view-mode data-align data-caption alt title>'
+      allowed_html: '<p class> <br> <a href hreflang data-entity-type data-entity-uuid data-entity-substitution title target class="dcf-btn dcf-btn-primary dcf-btn-secondary dcf-btn-tertiary dcf-btn-inverse-primary dcf-btn-inverse-secondary dcf-btn-inverse-tertiary"> <em> <strong> <cite> <blockquote cite> <ul type> <ol start type> <li> <h2 id> <h3 id> <s> <sup> <sub> <table class> <caption> <tbody> <thead> <tfoot> <th> <td> <tr> <drupal-media data-entity-type data-entity-uuid data-view-mode data-align data-caption alt title>'
       filter_html_help: true
       filter_html_nofollow: false
   filter_autop:


### PR DESCRIPTION
This PR seeks to make a number of changes to text formats:

Standard and Block Body

- Allow the following classes to be added to `<p>` elements
  - dcf-txt-xs
  - dcf-txt-sm
  - dcf-txt-md
  - dcf-txt-lg
  - unl-font-serif

Block Body

- Allow H2 and H3 tags
- Allow media to be embedded