### PR TITLE
Replace Chosen with Select2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,10 @@
             "url": "https://packages.drupal.org/8"
         },
         {
+            "type": "composer",
+            "url": "https://asset-packagist.org"
+        },
+        {
             "type": "vcs",
             "url": "https://github.com/unlcms/project-herbie-composer-plugin.git"
         },
@@ -148,6 +152,7 @@
         "drupal/pathauto": "^1.3",
         "drupal/rabbit_hole": "^1.0@beta",
         "drupal/redirect": "^1.5",
+        "drupal/select2": "^1.13",
         "drupal/token": "^1.0",
         "drupal/twig_tweak": "^2.0",
         "drupal/twig_ui": "^1.0@beta",
@@ -155,6 +160,7 @@
         "drush/drush": "^9.0.0",
         "jackocnr/intl-tel-input": "16.1.0",
         "nigelotoole/progress-tracker": "^2.0",
+        "npm-asset/select2": "^4.0",
         "oomphinc/composer-installers-extender": "^2.0",
         "ractoon/jquery-text-counter": "0.9.0",
         "robinherbots/jquery.inputmask": "5.0.5",
@@ -203,9 +209,14 @@
         "patchLevel": {
             "drupal/core": "-p2"
         },
+        "installer-types": ["bower-asset", "npm-asset"],
         "installer-paths": {
             "web/core": ["type:drupal-core"],
-            "web/libraries/{$name}": ["type:drupal-library"],
+            "web/libraries/{$name}": [
+                "type:drupal-library",
+                "type:bower-asset",
+                "type:npm-asset"
+            ],
             "web/modules/contrib/{$name}": ["type:drupal-module"],
             "web/profiles/contrib/{$name}": ["type:drupal-profile"],
             "web/themes/contrib/{$name}": ["type:drupal-theme"],

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fd8a31a887f3620ce86a9d46c0d03080",
+    "content-hash": "23da548e1998a6b2d7f4a67e52c47195",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -5313,6 +5313,69 @@
             }
         },
         {
+            "name": "drupal/select2",
+            "version": "1.13.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/select2.git",
+                "reference": "8.x-1.13"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/select2-8.x-1.13.zip",
+                "reference": "8.x-1.13",
+                "shasum": "c02f8591104310a6395788c33e44dfab5ec6a2c1"
+            },
+            "require": {
+                "drupal/core": "^8.8 || ^9"
+            },
+            "require-dev": {
+                "drupal/better_exposed_filters": "^5.0",
+                "drupal/facets": "^1.5",
+                "drupal/form_options_attributes": "^1.2",
+                "drupal/search_api": "^1.17"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-1.13",
+                    "datestamp": "1614609946",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Fritsch",
+                    "homepage": "https://www.drupal.org/user/1133806",
+                    "email": "christian.fritsch@burda.com"
+                },
+                {
+                    "name": "chr.fritsch",
+                    "homepage": "https://www.drupal.org/user/2103716"
+                },
+                {
+                    "name": "oushen",
+                    "homepage": "https://www.drupal.org/user/1200780"
+                },
+                {
+                    "name": "thunderbot",
+                    "homepage": "https://www.drupal.org/user/3511180"
+                }
+            ],
+            "description": "Integration with the select2 JavaScript library.",
+            "homepage": "https://www.drupal.org/project/select2",
+            "support": {
+                "source": "https://git.drupalcode.org/project/select2"
+            }
+        },
+        {
             "name": "drupal/token",
             "version": "1.8.0",
             "source": {
@@ -7017,6 +7080,18 @@
                 "php"
             ],
             "time": "2019-02-16T20:54:15+00:00"
+        },
+        {
+            "name": "npm-asset/select2",
+            "version": "4.0.13",
+            "dist": {
+                "type": "tar",
+                "url": "https://registry.npmjs.org/select2/-/select2-4.0.13.tgz"
+            },
+            "type": "npm-asset",
+            "license": [
+                "MIT"
+            ]
         },
         {
             "name": "oomphinc/composer-installers-extender",

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -80,6 +80,7 @@ module:
   redirect: 0
   responsive_image: 0
   rh_media: 0
+  select2: 0
   shortcut: 0
   syslog: 0
   system: 0


### PR DESCRIPTION
The Chosen library was deprecated on 17 Jan 2020. The Drupal Chosen projected is also being considered for deprecation: https://www.drupal.org/project/chosen/issues/3203875

This issue seeks to replace Chosen with [Select2](https://www.drupal.org/project/select2).

