### PR TITLE
News Importer should truncate character-limited field

### DIFF
--- a/web/modules/custom/unl_news/src/Plugin/QueueWorker/NebraskaTodayQueueProcessor.php
+++ b/web/modules/custom/unl_news/src/Plugin/QueueWorker/NebraskaTodayQueueProcessor.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\unl_news\Plugin\QueueWorker;
 
+use Drupal\Component\Utility\Unicode;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\File\FileSystemInterface;
@@ -126,7 +127,10 @@ class NebraskaTodayQueueProcessor extends QueueWorkerBase implements ContainerFa
     $node = Node::create([
       'type' => 'news',
     ]);
-    $node->set('title', $item->title);
+    // Truncate title to 255 characters as is allowed by the
+    // node title field.
+    $title = Unicode::truncate($item->title, 255, TRUE, TRUE);
+    $node->set('title', $title);
     $node->set('n_news_foreign_key', $item->id);
     $node->set('n_news_canonical_url', $item->canonicalUrl);
 
@@ -148,7 +152,9 @@ class NebraskaTodayQueueProcessor extends QueueWorkerBase implements ContainerFa
         $filename = explode('/', $remote_image_url);
         $filename = end($filename);
 
-        $alt = $item->articleImage->alt;
+        // Truncate alt text to 512 characters as is allowed by the
+        // n_news_image_alt field.
+        $alt = Unicode::truncate($item->articleImage->alt, 512, TRUE, TRUE);
 
         // Get image upload path from field config.
         /** @var \Drupal\field\Entity\FieldConfig */


### PR DESCRIPTION
Currently, the News Importer doesn't take into account the character limit of fields when importing news content. If the imported data character length exceeds the field max-character limit, then errors like the following will occur:

Queue Task Worker: Nebraska Today Articles errors:

```
    SQLSTATE[22001]: String data, right truncated: 1406 Data too long for column 'n_news_image_alt' at row 1: INSERT INTO {node__n_news_image} (entity_id, revision_id, bundle, delta, langcode, n_news_image_target_id, n_news_image_alt, n_news_image_title, n_news_image_width, n_news_image_height) VALUES (:db_insert_placeholder_0, :db_insert_placeholder_1, :db_insert_placeholder_2, :db_insert_placeholder_3, :db_insert_placeholder_4, :db_insert_placeholder_5, :db_insert_placeholder_6, :db_insert_placeholder_7, :db_insert_placeholder_8, :db_insert_placeholder_9); Array ( [:db_insert_placeholder_0] => 301 [:db_insert_placeholder_1] => 301 [:db_insert_placeholder_2] => news [:db_insert_placeholder_3] => 0 [:db_insert_placeholder_4] => en [:db_insert_placeholder_5] => 285 [:db_insert_placeholder_6] => Jack Dohrman (left) and and Shawn Languis (right), use tape measures to gauge physical distancing needs within an Avery Hall classroom. Keith Derickson, a support manager with academic technologies, stands in the instructor position to assist with the mapping. Based on their measurements, seating in this classroom will shift from 35 desks in a regular semester to 14 in the fall. The change allows the university meet the six-foot social distancing needs related to COVID-19. In large lecture halls, seating capacity is expected to be reduced to 20 percent. [:db_insert_placeholder_7] => [:db_insert_placeholder_8] => 1760 [:db_insert_placeholder_9] => 990 )
    SQLSTATE[22001]: String data, right truncated: 1406 Data too long for column 'n_news_image_alt' at row 1: INSERT INTO {node__n_news_image} (entity_id, revision_id, bundle, delta, langcode, n_news_image_target_id, n_news_image_alt, n_news_image_title, n_news_image_width, n_news_image_height) VALUES (:db_insert_placeholder_0, :db_insert_placeholder_1, :db_insert_placeholder_2, :db_insert_placeholder_3, :db_insert_placeholder_4, :db_insert_placeholder_5, :db_insert_placeholder_6, :db_insert_placeholder_7, :db_insert_placeholder_8, :db_insert_placeholder_9); Array ( [:db_insert_placeholder_0] => 352 [:db_insert_placeholder_1] => 352 [:db_insert_placeholder_2] => news [:db_insert_placeholder_3] => 0 [:db_insert_placeholder_4] => en [:db_insert_placeholder_5] => 333 [:db_insert_placeholder_6] => Nebraska National Guard members with the 155th Medical Group prepare a worksite for COVID-19 testing in Grand Island on April 7. The medical group, which includes Gabe Chase, is part of the Chemical, Biological, Radiological, Nuclear and Explosive Enhanced Response Force Package team. The team is an joint-force unit between the Army and Air National Guard and specializes in search and extraction, decontamination, medical, facilities search and rescue, and joint incident site communications command and control. [:db_insert_placeholder_7] => [:db_insert_placeholder_8] => 1760 [:db_insert_placeholder_9] => 990 ) 
```

This PR seeks to truncate incoming data to the respective field limits