### PR TITLE
Add News Aggregation Block

### DIFF
--- a/config/sync/core.entity_view_display.node.builder_page.default.yml
+++ b/config/sync/core.entity_view_display.node.builder_page.default.yml
@@ -86,6 +86,7 @@ third_party_settings:
         dcf_onecol_section:
           all_regions:
             'Aggregated Content':
+              - unl_news_aggregation
               - unl_recent_news
               - unl_upcoming_events
             'Content fields':

--- a/web/modules/custom/unl_news/templates/unl-news-news-aggregation-block.html.twig
+++ b/web/modules/custom/unl_news/templates/unl-news-news-aggregation-block.html.twig
@@ -1,0 +1,15 @@
+<div class="news-aggregation-block">
+  <h2>News</h2>
+  <div class="items">
+    {% for item in items %}
+      <article class="item">
+        {{ item.image }}
+        {% if item.source == 'remote' %}
+          <div class="ne-today">From Nebraska Today</div>
+        {% endif %}
+        <h3 class="title-link"><a href="{{ item.link }}">{{ item.title }}</a></h3>
+      </article>
+    {% endfor %}
+  </div>
+  {{ pager }}
+</div>

--- a/web/modules/custom/unl_news/unl_news.module
+++ b/web/modules/custom/unl_news/unl_news.module
@@ -23,6 +23,12 @@ function unl_news_theme($existing, $type, $theme, $path) {
         'more_link' => '',
       ],
     ],
+    'unl_news_news_aggregation_block' => [
+      'variables' => [
+        'items' => [],
+        'pager' => [],
+      ],
+    ],
   ];
 }
 

--- a/web/themes/custom/unl_five_herbie/templates/block/unl-news-news-aggregation-block.html.twig
+++ b/web/themes/custom/unl_five_herbie/templates/block/unl-news-news-aggregation-block.html.twig
@@ -1,0 +1,22 @@
+<div class="dcf-bleed dcf-wrapper dcf-pt-9 dcf-pb-9">
+  <div class="dcf-grid-halves@sm dcf-grid-fourths@md dcf-col-gap-5 dcf-row-gap-6">
+    {% for item in items %}
+      <article class="dcf-card-as-link dcf-d-flex dcf-flex-col">
+        <div class="dcf-2nd dcf-pt-2">
+          {% if item.source == 'remote' %}
+            <div class="dcf-mb-4 dcf-badge dcf-badge-pill unl-bg-scarlet">From Nebraska Today</div>
+          {% endif %}
+          <h3 class="dcf-txt-h5 dcf-mb-0"><a class="dcf-card-link dcf-txt-decor-hover" href="{{ item.link }}">{{ item.title }}</a></h3>
+        </div>
+        <div class="dcf-ratio dcf-ratio-16x9 dcf-1st unl-frame-quad unl-bg-light-gray">
+          {{ item.image }}
+        </div>
+      </article>
+    {% endfor %}
+  </div>
+  <div class="dcf-mt-4 dcf-txt-center">
+    {{ pager }}
+  </div>
+</div>
+{{ attach_library('unl_five/wdn-scroll-animiations') }}
+{{ attach_library('unl_five/wdn-card-as-link') }}


### PR DESCRIPTION
This PR seeks to add a news aggregation block. It's basically an adaptation of the existing recent news block. The only configuration is the number of items to display on a page.

Code provided by front-end dev:
```html
<script>
  window.addEventListener('inlineJSReady', function() {
    WDN.initializePlugin('scroll-animations');
  }, false);
</script>
<div class="dcf-bleed dcf-wrapper dcf-pt-9 dcf-pb-9">
  <h2 id="news-teasers-aggregation-heading">News</h2>
  <ul class="dcf-list-bare dcf-mb-0 dcf-grid-halves@sm dcf-grid-thirds@md dcf-grid-fourths@lg dcf-col-gap-vw dcf-row-gap-6" aria-labelledby="news-teasers-aggregation-heading">
    <li class="dcf-mb-0">
      <article class="dcf-card-as-link dcf-d-flex dcf-flex-col">
        <div class="dcf-2nd dcf-pt-2">
          <div class="dcf-mb-4 dcf-badge dcf-badge-pill unl-bg-scarlet">From Nebraska Today</div>
          <h3 class="dcf-txt-h5 dcf-mb-0"><a class="dcf-card-link dcf-txt-decor-hover" href="#">Team IDs key to sorghum’s heat resilience, aims to boost corn’s tolerance</a></h3>
        </div>
        <div class="dcf-ratio dcf-ratio-16x9 dcf-1st unl-frame-quad unl-bg-light-gray">
          <picture>
      <!--
            <source
              data-sizes=""
              data-srcset="
                wdn/templates_5.3/images/dev/150821-tunnel-325-sm-min.avif 284w,
                wdn/templates_5.3/images/dev/150821-tunnel-325-md-min.avif 505w,
                wdn/templates_5.3/images/dev/150821-tunnel-325-lg-min.avif 898w,
                wdn/templates_5.3/images/dev/150821-tunnel-325-xl-min.avif 1596w"
              srcset="data:,1w"
              type="image/avif">
            <source
              data-sizes=""
              data-srcset="
                wdn/templates_5.3/images/dev/150821-tunnel-325-sm-min.webp 284w,
                wdn/templates_5.3/images/dev/150821-tunnel-325-md-min.webp 505w,
                wdn/templates_5.3/images/dev/150821-tunnel-325-lg-min.webp 898w,
                wdn/templates_5.3/images/dev/150821-tunnel-325-xl-min.webp 1596w"
              srcset="data:,1w"
              type="image/webp">
      -->
            <source
              data-sizes=""
              data-srcset="
                wdn/templates_5.3/images/dev/150821-tunnel-325-sm-min.jpg 284w,
                wdn/templates_5.3/images/dev/150821-tunnel-325-md-min.jpg 505w,
                wdn/templates_5.3/images/dev/150821-tunnel-325-lg-min.jpg 898w,
                wdn/templates_5.3/images/dev/150821-tunnel-325-xl-min.jpg 1596w"
              srcset="data:,1w"
              type="image/jpeg">
            <img
              class="dcf-ratio-child dcf-obj-fit-cover dcf-fade-in dcf-animate-on-scroll dcf-lazy-load dcf-animate"
              data-src="wdn/templates_5.3/images/dev/150821-tunnel-325-sm-min.jpg"
              src="data:,"
              height="202"
              width="284"
              loading="lazy"
              decoding="async"
              aria-hidden="true"
              alt="">
          </picture>
          <noscript>
            <img
              class="dcf-ratio-child dcf-obj-fit-cover"
              src="wdn/templates_5.3/images/dev/150821-tunnel-325-sm-min.jpg"
              height="202"
              width="284"
              aria-hidden="true"
              alt="">
          </noscript>
        </div>
      </article>
    </li>
  </ul>
  <ol class="dcf-list-bare dcf-list-inline dcf-mt-6">
    <li>1</li>
    <li><a href="#">2</a></li>
    <li><a href="#">3</a></li>
    <li>…</li>
    <li><a href="#">next</a></li>
    <li><a href="#">last</a></li>
  </ol>
</div>
```