### PR TITLE
Allow Card + Circle Image block type for all Layout Builder regions

### DIFF
--- a/config/sync/core.entity_view_display.node.builder_page.default.yml
+++ b/config/sync/core.entity_view_display.node.builder_page.default.yml
@@ -157,6 +157,7 @@ third_party_settings:
             'Inline blocks':
               - 'inline_block:accordion'
               - 'inline_block:card'
+              - 'inline_block:card_circle_image'
               - 'inline_block:content'
               - 'inline_block:html_code'
             'Lists (Views)': {  }


### PR DESCRIPTION
Currently, the _Card + Circle Image_ block type is allowed for all LB regions, except for those in the TWO COLUMN (DCF) layout. This PR seeks to all the block type for all LB regions.