### PR TITLE
Implement DCF Image Lazy Loading

### DIFF
--- a/config/sync/core.entity_view_display.block_content.card.default.yml
+++ b/config/sync/core.entity_view_display.block_content.card.default.yml
@@ -15,6 +15,7 @@ dependencies:
     - field.field.block_content.card.b_card_subhead
     - responsive_image.styles.card_block
   module:
+    - dcf_lazyload
     - link
     - options
     - responsive_image
@@ -83,7 +84,9 @@ content:
     settings:
       responsive_image_style: card_block
       image_link: ''
-    third_party_settings: {  }
+    third_party_settings:
+      dcf_lazyload:
+        dcf_lazyload_enable: true
     type: responsive_image
     region: content
   b_card_overline:

--- a/config/sync/core.entity_view_display.block_content.card_circle_image.default.yml
+++ b/config/sync/core.entity_view_display.block_content.card_circle_image.default.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.block_content.card_circle_image.b_cdcir_image
     - responsive_image.styles.card_circle_image_block
   module:
+    - dcf_lazyload
     - link
     - responsive_image
     - text
@@ -64,7 +65,9 @@ content:
     settings:
       responsive_image_style: card_circle_image_block
       image_link: ''
-    third_party_settings: {  }
+    third_party_settings:
+      dcf_lazyload:
+        dcf_lazyload_enable: true
     type: responsive_image
     region: content
 hidden: {  }

--- a/config/sync/core.entity_view_display.block_content.hero.default.yml
+++ b/config/sync/core.entity_view_display.block_content.hero.default.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.block_content.hero.b_hero_title
     - responsive_image.styles.hero_medium
   module:
+    - dcf_lazyload
     - options
     - responsive_image
 id: block_content.hero.default
@@ -24,7 +25,9 @@ content:
     settings:
       responsive_image_style: hero_medium
       image_link: ''
-    third_party_settings: {  }
+    third_party_settings:
+      dcf_lazyload:
+        dcf_lazyload_enable: true
     type: responsive_image
     region: content
   b_hero_overline:

--- a/config/sync/core.entity_view_display.media.image.narrow.yml
+++ b/config/sync/core.entity_view_display.media.image.narrow.yml
@@ -12,6 +12,7 @@ dependencies:
     - media.type.image
     - responsive_image.styles.narrow
   module:
+    - dcf_lazyload
     - layout_builder
     - responsive_image
 third_party_settings:
@@ -31,7 +32,9 @@ content:
     settings:
       responsive_image_style: narrow
       image_link: ''
-    third_party_settings: {  }
+    third_party_settings:
+      dcf_lazyload:
+        dcf_lazyload_enable: true
 hidden:
   created: true
   name: true

--- a/config/sync/core.entity_view_display.media.image.wide.yml
+++ b/config/sync/core.entity_view_display.media.image.wide.yml
@@ -12,6 +12,7 @@ dependencies:
     - media.type.image
     - responsive_image.styles.wide
   module:
+    - dcf_lazyload
     - layout_builder
     - responsive_image
 third_party_settings:
@@ -29,7 +30,9 @@ content:
     settings:
       responsive_image_style: wide
       image_link: ''
-    third_party_settings: {  }
+    third_party_settings:
+      dcf_lazyload:
+        dcf_lazyload_enable: true
     type: responsive_image
     region: content
 hidden:

--- a/config/sync/core.entity_view_display.node.news.default.yml
+++ b/config/sync/core.entity_view_display.node.news.default.yml
@@ -12,6 +12,7 @@ dependencies:
     - node.type.news
     - responsive_image.styles.news_lead_image
   module:
+    - dcf_lazyload
     - link
     - responsive_image
     - text
@@ -62,7 +63,9 @@ content:
     settings:
       responsive_image_style: news_lead_image
       image_link: ''
-    third_party_settings: {  }
+    third_party_settings:
+      dcf_lazyload:
+        dcf_lazyload_enable: true
   n_news_image_credit:
     type: string
     weight: 2

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -115,6 +115,7 @@ module:
   webform: 0
   webform_submission_log: 0
   webform_ui: 0
+  dcf_lazyload: 1
   menu_admin_per_menu: 1
   menu_link_content: 1
   pathauto: 1


### PR DESCRIPTION
Lazy loading is currently in development for DCF. We'll need this prior to launch. Currently, images that use srcset are using sizes=100vw. This is because we don't know the actual size the image needs to be when rendering the markup. We need JS to figure that out, and that's where DCF comes in.