### PR TITLE
Disable DCF Lazyload for Heros

### DIFF
--- a/config/sync/core.entity_view_display.block_content.hero.default.yml
+++ b/config/sync/core.entity_view_display.block_content.hero.default.yml
@@ -27,7 +27,7 @@ content:
       image_link: ''
     third_party_settings:
       dcf_lazyload:
-        dcf_lazyload_enable: true
+        dcf_lazyload_enable: false
     type: responsive_image
     region: content
   b_hero_overline:


### PR DESCRIPTION
In #109, DCF Lazyload was enabled for all rendered images on the site. It's causing undesired behavior with hero images:

![MicrosoftTeams-image](https://user-images.githubusercontent.com/1521132/130512931-f94343b8-c798-44e4-83ad-b8453195ce64.png)

 In any event, it's not needed. The images will always be rendered on initial page load given their position. They're always 100vw, so there's no need to calculate the `sizes` attribute.