### PR TITLE
Patch for CssTrait::itemPrefixes applied

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -290,6 +290,9 @@
             },
             "drush/drush": {
                 "Custom - Do not allow config:import to be run": "patches/drush-config-import-message.patch"
+            },
+            "drupal/field_css": {
+                "3313270 - update depricated function": "patches/depricated-function-itemprefixes-3313270-01.patch"
             }
         },
         "drupal-scaffold": {

--- a/patches/depricated-function-itemprefixes-3313270-01.patch
+++ b/patches/depricated-function-itemprefixes-3313270-01.patch
@@ -1,0 +1,14 @@
+diff --git a/field_css.module b/field_css.module
+index 4b8c604..29e5b28 100644
+--- a/field_css.module
++++ b/field_css.module
+@@ -17,7 +17,8 @@ use Drupal\field_css\Traits\CssTrait;
+  * Implements hook_entity_view_alter().
+  */
+ function field_css_entity_view_alter(array &$build, EntityInterface $entity, EntityViewDisplayInterface $display) {
+-  $prefixes = CssTrait::itemPrefixes($entity, $display->getMode());
++
++  $prefixes = (new class { use CssTrait; })::itemPrefixes($entity, $display->getMode());
+
+   if ($prefixes) {
+     foreach ($prefixes as $prefix) {


### PR DESCRIPTION
Fix error showing on govboard test site

Deprecated function: Calling static trait method Drupal\field_css\Traits\CssTrait::itemPrefixes is deprecated, it should only be called on a class using the trait in field_css_entity_view_alter() (line 20 of modules/contrib/field_css/field_css.module)

Closes #394 