### PR TITLE
Removed Drupal's favicon use option

### DIFF
--- a/config/sync/unl_five.settings.yml
+++ b/config/sync/unl_five.settings.yml
@@ -1,6 +1,13 @@
 features:
   logo: false
   slogan: true
-  favicon: false
+  favicon: 0
+  node_user_picture: false
+  comment_user_picture: true
+  comment_user_verification: true
 _core:
   default_config_hash: RzrFjHolQT4-m--ddhSf6ZZ-CQsPcP1Ln3IvgHsWPxk
+logo:
+  use_default: 1
+favicon:
+  use_default: 1

--- a/config/sync/unl_five_herbie.settings.yml
+++ b/config/sync/unl_five_herbie.settings.yml
@@ -1,0 +1,10 @@
+features:
+  node_user_picture: false
+  comment_user_picture: true
+  comment_user_verification: true
+  favicon: 1
+logo:
+  use_default: 1
+favicon:
+  use_default: 0
+  path: ''


### PR DESCRIPTION
Closes #514 

vendor/bin/drush config:set --input-format=yaml unl_five.settings '?' "{features: {logo: false, slogan: true, favicon: 0, node_user_picture: false, comment_user_picture: true, comment_user_verification: true}, logo: {use_default: 1}, favicon: {use_default: 1}}"

I believe I need one more drush command for **unl_five_herbie.settings.yml** but the setting file for that doesn't exist so I am not sure how to go about that. 