### PR TITLE
Favicon fix 2

### DIFF
--- a/config/sync/unl_five.settings.yml
+++ b/config/sync/unl_five.settings.yml
@@ -1,7 +1,7 @@
 features:
   logo: false
   slogan: true
-  favicon: 0
+  favicon: true
   node_user_picture: false
   comment_user_picture: true
   comment_user_verification: true
@@ -10,4 +10,4 @@ _core:
 logo:
   use_default: 1
 favicon:
-  use_default: 1
+  use_default: false

--- a/config/sync/unl_five_herbie.settings.yml
+++ b/config/sync/unl_five_herbie.settings.yml
@@ -2,9 +2,9 @@ features:
   node_user_picture: false
   comment_user_picture: true
   comment_user_verification: true
-  favicon: 1
+  favicon: true
 logo:
   use_default: 1
 favicon:
-  use_default: 0
+  use_default: false
   path: ''


### PR DESCRIPTION
Closes #591 

Previous issue id #514 and pull request #540

I initially just committed the automatic changes it made to the config files after I did a config export. I think it wasn't set right. This should fix the issue.

vendor/bin/drush config:set --input-format=yaml unl_five.settings '?' "{features: {logo: false, slogan: true, favicon: true, node_user_picture: false, comment_user_picture: true, comment_user_verification: true}, logo: {use_default: 1}, favicon: {use_default: false}}"


To create the unl_five_herbie.settings.yml file using drush, maybe doing this might work? https://github.com/drush-ops/drush/pull/5370/commits/5d954c5e29d61f3e19daa3031b0a8fbce744f9a5 do we want to do that?


- **_12/19/2023_** 

I am going to change this pull request to a draft. We would want to merge https://github.com/unlcms/project-herbie/pull/592) pull request instead 
