### PR TITLE
title tag changes #582

### DIFF
--- a/config/sync/metatag.metatag_defaults.front.yml
+++ b/config/sync/metatag.metatag_defaults.front.yml
@@ -9,3 +9,4 @@ label: 'Front page'
 tags:
   canonical_url: '[site:url]'
   shortlink: '[site:url]'
+  title: '[current-page:title] | [site:name] | Nebraska'

--- a/config/sync/metatag.metatag_defaults.global.yml
+++ b/config/sync/metatag.metatag_defaults.global.yml
@@ -8,4 +8,4 @@ id: global
 label: Global
 tags:
   canonical_url: '[current-page:url]'
-  title: '[current-page:title] | [site:name]'
+  title: '[current-page:title] | [site:name] | Nebraska'

--- a/config/sync/metatag.metatag_defaults.node.yml
+++ b/config/sync/metatag.metatag_defaults.node.yml
@@ -7,6 +7,6 @@ _core:
 id: node
 label: Content
 tags:
-  title: '[node:title] | [site:name]'
-  description: '[node:summary]'
   canonical_url: '[node:url]'
+  description: '[node:summary]'
+  title: '[node:title] | [site:name] | Nebraska'


### PR DESCRIPTION
Closes #582 

I believe we want these drush commands to change the default module settings...

```
vendor/bin/drush config:set --input-format=yaml metatag.metatag_defaults.global tags.title "'[current-page:title] | [site:name] | Nebraska'"

vendor/bin/drush config:set --input-format=yaml metatag.metatag_defaults.front tags.title "'[current-page:title] | [site:name] | Nebraska'"

vendor/bin/drush config:set --input-format=yaml metatag.metatag_defaults.node tags.title "'[node:title] | [site:name] | Nebraska'"
```