### PR TITLE
Version 1.0.1. Created and installed the herbie_config feature #585

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -67,6 +67,7 @@ module:
   heading: 0
   herbie_book: 0
   herbie_builder_page: 0
+  herbie_config: 0
   herbie_entity_share: 0
   herbie_major: 0
   herbie_media_types: 0

--- a/web/modules/custom/features/herbie_config/herbie_config.features.yml
+++ b/web/modules/custom/features/herbie_config/herbie_config.features.yml
@@ -1,0 +1,1 @@
+bundle: herbie

--- a/web/modules/custom/features/herbie_config/herbie_config.features.yml
+++ b/web/modules/custom/features/herbie_config/herbie_config.features.yml
@@ -1,1 +1,2 @@
 bundle: herbie
+required: true

--- a/web/modules/custom/features/herbie_config/herbie_config.info.yml
+++ b/web/modules/custom/features/herbie_config/herbie_config.info.yml
@@ -1,0 +1,6 @@
+name: 'Herbie config'
+description: 'A bundle of miscellaneous configuration files, mainly to override default configuration in modules or other settings. '
+type: module
+core_version_requirement: '^9.4 || ^10'
+version: 1.0.1
+package: Herbie


### PR DESCRIPTION
closes #585

I created and installed the herbie_config feature. 

I think this command might be needed to install the feature on all sites... php drush-all-sites.php pm:enable hebrie_config

I will be using this feature for the favicon issue that is currently open to obtain the config install files