### PR TITLE
Favicon get install configs #591

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -67,6 +67,7 @@ module:
   heading: 0
   herbie_book: 0
   herbie_builder_page: 0
+  herbie_config: 0
   herbie_entity_share: 0
   herbie_major: 0
   herbie_media_types: 0

--- a/web/modules/custom/features/herbie_config/config/install/unl_five.settings.yml
+++ b/web/modules/custom/features/herbie_config/config/install/unl_five.settings.yml
@@ -1,0 +1,11 @@
+features:
+  logo: false
+  slogan: true
+  favicon: 1
+  node_user_picture: false
+  comment_user_picture: true
+  comment_user_verification: true
+logo:
+  use_default: 1
+favicon:
+  use_default: 0

--- a/web/modules/custom/features/herbie_config/config/install/unl_five_herbie.settings.yml
+++ b/web/modules/custom/features/herbie_config/config/install/unl_five_herbie.settings.yml
@@ -1,0 +1,10 @@
+features:
+  node_user_picture: false
+  comment_user_picture: true
+  comment_user_verification: true
+  favicon: 1
+logo:
+  use_default: 1
+favicon:
+  use_default: 0
+  path: ''

--- a/web/modules/custom/features/herbie_config/herbie_config.features.yml
+++ b/web/modules/custom/features/herbie_config/herbie_config.features.yml
@@ -1,1 +1,4 @@
 bundle: herbie
+required:
+  - unl_five.settings
+  - unl_five_herbie.settings

--- a/web/modules/custom/features/herbie_config/herbie_config.features.yml
+++ b/web/modules/custom/features/herbie_config/herbie_config.features.yml
@@ -1,0 +1,1 @@
+bundle: herbie

--- a/web/modules/custom/features/herbie_config/herbie_config.info.yml
+++ b/web/modules/custom/features/herbie_config/herbie_config.info.yml
@@ -1,0 +1,6 @@
+name: 'Herbie config'
+description: 'A bundle of miscellaneous configuration files, mainly to override default configuration in modules or other settings. '
+type: module
+core_version_requirement: '^9.4 || ^10'
+version: 1.0.1
+package: Herbie

--- a/web/modules/custom/features/herbie_config/herbie_config.info.yml
+++ b/web/modules/custom/features/herbie_config/herbie_config.info.yml
@@ -2,5 +2,5 @@ name: 'Herbie config'
 description: 'A bundle of miscellaneous configuration files, mainly to override default configuration in modules or other settings. '
 type: module
 core_version_requirement: '^9.4 || ^10'
-version: 1.0.1
+version: 1.0.2
 package: Herbie


### PR DESCRIPTION
#591 

However, for this herbie_config feature to work, I believe this [pull request](https://github.com/unlcms/project-herbie/issues/585) would need to be completed.

I added unl_five.settings.yml and unl_five_herbie.settings.yml config install files. Maybe this will fix the favicon issue we are having on sites created before the first fix was pushed? Or we just need to do this https://github.com/unlcms/project-herbie/pull/557

`So I removed * @validate-config-name from /vendor/drush/drush/src/Drupal/Commands/config/ConfigCommands.php in my local project and it let me create the unl_five_herbie.settings.yml file using this command vendor/bin/drush config:set --input-format=yaml unl_five_herbie.settings '?' "{features: {node_user_picture: false, comment_user_picture: true, comment_user_verification: true, favicon: 1}, logo: {use_default: 1}, favicon: {use_default: 0, path: '' }}"`