### PR TITLE
Removed elements and margin class #680

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "df1e32a700532ef2e6286a1865c8e9cc",
+    "content-hash": "02f5f7b97f834cf3e86e3294af0b7a7f",
     "packages": [
         {
             "name": "arthurkushman/query-path",
@@ -9494,16 +9494,16 @@
         },
         {
             "name": "sabberworm/php-css-parser",
-            "version": "8.4.0",
+            "version": "v8.5.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sabberworm/PHP-CSS-Parser.git",
-                "reference": "e41d2140031d533348b2192a83f02d8dd8a71d30"
+                "url": "https://github.com/MyIntervals/PHP-CSS-Parser.git",
+                "reference": "4a3d572b0f8b28bb6fd016ae8bbfc445facef152"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sabberworm/PHP-CSS-Parser/zipball/e41d2140031d533348b2192a83f02d8dd8a71d30",
-                "reference": "e41d2140031d533348b2192a83f02d8dd8a71d30",
+                "url": "https://api.github.com/repos/MyIntervals/PHP-CSS-Parser/zipball/4a3d572b0f8b28bb6fd016ae8bbfc445facef152",
+                "reference": "4a3d572b0f8b28bb6fd016ae8bbfc445facef152",
                 "shasum": ""
             },
             "require": {
@@ -9511,13 +9511,17 @@
                 "php": ">=5.6.20"
             },
             "require-dev": {
-                "codacy/coverage": "^1.4",
-                "phpunit/phpunit": "^4.8.36"
+                "phpunit/phpunit": "^5.7.27"
             },
             "suggest": {
                 "ext-mbstring": "for parsing UTF-8 CSS"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "9.0.x-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "Sabberworm\\CSS\\": "src/"
@@ -9530,6 +9534,14 @@
             "authors": [
                 {
                     "name": "Raphael Schweikert"
+                },
+                {
+                    "name": "Oliver Klee",
+                    "email": "github@oliverklee.de"
+                },
+                {
+                    "name": "Jake Hotson",
+                    "email": "jake.github@qzdesign.co.uk"
                 }
             ],
             "description": "Parser for CSS Files written in PHP",
@@ -9540,10 +9552,10 @@
                 "stylesheet"
             ],
             "support": {
-                "issues": "https://github.com/sabberworm/PHP-CSS-Parser/issues",
-                "source": "https://github.com/sabberworm/PHP-CSS-Parser/tree/8.4.0"
+                "issues": "https://github.com/MyIntervals/PHP-CSS-Parser/issues",
+                "source": "https://github.com/MyIntervals/PHP-CSS-Parser/tree/v8.5.1"
             },
-            "time": "2021-12-11T13:40:54+00:00"
+            "time": "2024-02-15T16:41:13+00:00"
         },
         {
             "name": "softcreatr/jsonpath",

--- a/web/themes/custom/unl_five_herbie/templates/block/unl-person-person-list.html.twig
+++ b/web/themes/custom/unl_five_herbie/templates/block/unl-person-person-list.html.twig
@@ -21,7 +21,7 @@
     {% endfor %}
   </ul>
 {% else %}
-  <ol {{attributes.addClass(['dcf-list-bare', 'dcf-d-grid', 'unlcms-abbr-teaser-person-list', 'dcf-col-gap-vw', 'dcf-row-gap-6','dcf-mb-9'])}}>
+  <ol {{attributes.addClass(['dcf-list-bare', 'dcf-d-grid', 'unlcms-abbr-teaser-person-list', 'dcf-col-gap-vw', 'dcf-row-gap-6'])}}>
     {% for nid in nodes %}
       {{ drupal_entity('node', nid, view_mode) }}
     {% endfor %}

--- a/web/themes/custom/unl_five_herbie/templates/node/node--person--teaser-small.html.twig
+++ b/web/themes/custom/unl_five_herbie/templates/node/node--person--teaser-small.html.twig
@@ -1,7 +1,7 @@
-{% set classes = ['node', 'node--type-' ~ (node.bundle|clean_class), node.isPromoted() ? 'node--promoted', node.isSticky() ? 'node--sticky', not node.isPublished() ? 'node--unpublished', view_mode ? 'node--view-mode-' ~ (view_mode|clean_class), 'clearfix'] %}
+{% set classes = ['node', 'node--type-' ~ (node.bundle|clean_class), node.isPromoted() ? 'node--promoted', node.isSticky() ? 'node--sticky', not node.isPublished() ? 'node--unpublished', view_mode ? 'node--view-mode-' ~ (view_mode|clean_class), 'clearfix', 'dcf-mb-0', 'dcf-card-as-link', 'unlcms-img-zoom-hover'] %}
 
 {{ attach_library('unl_five_herbie/person') }}
-    <li class="dcf-mb-0 dcf-card-as-link unlcms-img-zoom-hover" itemscope itemtype="https://schema.org/Person">
+    <li  {{content_attributes.addClass(classes)}} itemscope itemtype="https://schema.org/Person">
       <div class="unlcms-person-img dcf-ratio dcf-ratio-1x1 dcf-mb-2 unl-bg-light-gray unl-frame-quad">
         {% if node.n_person_photo.value %}
           {{ content.n_person_photo }}

--- a/web/themes/custom/unl_five_herbie/templates/node/node--person--teaser-small.html.twig
+++ b/web/themes/custom/unl_five_herbie/templates/node/node--person--teaser-small.html.twig
@@ -1,9 +1,6 @@
 {% set classes = ['node', 'node--type-' ~ (node.bundle|clean_class), node.isPromoted() ? 'node--promoted', node.isSticky() ? 'node--sticky', not node.isPublished() ? 'node--unpublished', view_mode ? 'node--view-mode-' ~ (view_mode|clean_class), 'clearfix'] %}
 
 {{ attach_library('unl_five_herbie/person') }}
-
-<article {{ attributes.addClass(classes) }}>
-  <div {{ content_attributes }}>
     <li class="dcf-mb-0 dcf-card-as-link unlcms-img-zoom-hover" itemscope itemtype="https://schema.org/Person">
       <div class="unlcms-person-img dcf-ratio dcf-ratio-1x1 dcf-mb-2 unl-bg-light-gray unl-frame-quad">
         {% if node.n_person_photo.value %}
@@ -34,5 +31,3 @@
         {% endif %}
       </div>
     </li>
-  </div>
-</article>

--- a/web/themes/custom/unl_five_herbie/templates/node/node--person--teaser.html.twig
+++ b/web/themes/custom/unl_five_herbie/templates/node/node--person--teaser.html.twig
@@ -1,11 +1,11 @@
-{% set classes = ['node', 'node--type-' ~ (node.bundle|clean_class), node.isPromoted() ? 'node--promoted', node.isSticky() ? 'node--sticky', not node.isPublished() ? 'node--unpublished', view_mode ? 'node--view-mode-' ~ (view_mode|clean_class), 'clearfix'] %}
+{% set classes = ['node', 'node--type-' ~ (node.bundle|clean_class), node.isPromoted() ? 'node--promoted', node.isSticky() ? 'node--sticky', not node.isPublished() ? 'node--unpublished', view_mode ? 'node--view-mode-' ~ (view_mode|clean_class), 'clearfix', 'dcf-mb-0', 'dcf-card-as-link', 'unlcms-img-zoom-hover'] %}
 
 {{ attach_library('unl_five_herbie/person') }}
 
 {% set orderedListAttribute = create_attribute() %}
 {% set orderedListAttribute = orderedListAttribute.addClass('dcf-list-bare dcf-d-grid unlcms-teaser-person-list dcf-col-gap-vw dcf-row-gap-8 dcf-mb-9') %}
 
-    <li class="dcf-mb-0 dcf-card-as-link unlcms-img-zoom-hover" itemscope itemtype="https://schema.org/Person">
+    <li {{content_attributes.addClass(classes)}} itemscope itemtype="https://schema.org/Person">
       <div class="dcf-grid dcf-col-gap-5 dcf-row-gap-2 unlcms-teaser-person" data-uid="{{ node.n_person_unldirectoryreference.entity.ee_unldir_uid.value }}" data-preferred-name="{{ label }}" itemscope itemtype="http://schema.org/Person">
         <!-- Image -->
         <div class="unlcms-teaser-person-img">

--- a/web/themes/custom/unl_five_herbie/templates/node/node--person--teaser.html.twig
+++ b/web/themes/custom/unl_five_herbie/templates/node/node--person--teaser.html.twig
@@ -5,9 +5,6 @@
 {% set orderedListAttribute = create_attribute() %}
 {% set orderedListAttribute = orderedListAttribute.addClass('dcf-list-bare dcf-d-grid unlcms-teaser-person-list dcf-col-gap-vw dcf-row-gap-8 dcf-mb-9') %}
 
-{# Why in an article tag? #}
-<article {{ attributes.addClass(classes) }}>
-  <div {{ content_attributes }}>
     <li class="dcf-mb-0 dcf-card-as-link unlcms-img-zoom-hover" itemscope itemtype="https://schema.org/Person">
       <div class="dcf-grid dcf-col-gap-5 dcf-row-gap-2 unlcms-teaser-person" data-uid="{{ node.n_person_unldirectoryreference.entity.ee_unldir_uid.value }}" data-preferred-name="{{ label }}" itemscope itemtype="http://schema.org/Person">
         <!-- Image -->
@@ -271,5 +268,3 @@
         </div>
       </div>
     </li>
-  </div>
-</article>


### PR DESCRIPTION
closes #680 

Added the content_attributes to the li tag instead of a div.
Not sure why but made me change the hash code in the composer.lock file. I didn't update any modules but my site was letting me know that the field_css module wasn't installed so I had to use composer to install it. That's how the hash was automatically modified. 