### PR TITLE
Changed Tab component's Block body text format to Standard fixes #714

### DIFF
--- a/config/sync/field.field.paragraph.tab_item.p_b_tab_item_body.yml
+++ b/config/sync/field.field.paragraph.tab_item.p_b_tab_item_body.yml
@@ -11,7 +11,7 @@ dependencies:
 third_party_settings:
   allowed_formats:
     allowed_formats:
-      - block_body
+      - standard
 id: paragraph.tab_item.p_b_tab_item_body
 field_name: p_b_tab_item_body
 entity_type: paragraph

--- a/web/modules/custom/features/herbie_builder_page/config/install/field.field.paragraph.tab_item.p_b_tab_item_body.yml
+++ b/web/modules/custom/features/herbie_builder_page/config/install/field.field.paragraph.tab_item.p_b_tab_item_body.yml
@@ -10,7 +10,7 @@ dependencies:
 third_party_settings:
   allowed_formats:
     allowed_formats:
-      - block_body
+      - standard
 id: paragraph.tab_item.p_b_tab_item_body
 field_name: p_b_tab_item_body
 entity_type: paragraph

--- a/web/modules/custom/features/herbie_builder_page/herbie_builder_page.info.yml
+++ b/web/modules/custom/features/herbie_builder_page/herbie_builder_page.info.yml
@@ -73,5 +73,5 @@ dependencies:
   - 'unl_news:unl_news'
   - 'webform:webform'
   - 'webform:webform_submission_log'
-version: 1.7.1
+version: 1.7.2
 package: Herbie


### PR DESCRIPTION
These other plugins in the Standard text format will also be available. Is that acceptable? 
<img width="1265" alt="image" src="https://github.com/unlcms/project-herbie/assets/72580736/22aa7f21-6676-4fe7-b7f5-598c64ccc72d">