### PR TITLE
Prod Error: Group content not viewable 754

### DIFF
--- a/config/sync/core.entity_form_display.node.person.default.yml
+++ b/config/sync/core.entity_form_display.node.person.default.yml
@@ -90,12 +90,6 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
-  moderation_state:
-    type: moderation_state_default
-    weight: 15
-    region: content
-    settings: {  }
-    third_party_settings: {  }
   entitygroupfield:
     type: entitygroupfield_select_widget
     weight: 15

--- a/web/modules/custom/features/herbie_archive_page/config/install/core.entity_view_display.node.archive_page.default.yml
+++ b/web/modules/custom/features/herbie_archive_page/config/install/core.entity_view_display.node.archive_page.default.yml
@@ -31,4 +31,5 @@ content:
     weight: 0
     region: content
 hidden:
+  entitygroupfield: true
   s_n_page_options: true

--- a/web/modules/custom/features/herbie_archive_page/config/install/core.entity_view_display.node.archive_page.teaser.yml
+++ b/web/modules/custom/features/herbie_archive_page/config/install/core.entity_view_display.node.archive_page.teaser.yml
@@ -25,4 +25,5 @@ content:
     region: content
 hidden:
   archive_page_body: true
+  entitygroupfield: true
   s_n_page_options: true

--- a/web/modules/custom/features/herbie_archive_page/herbie_archive_page.info.yml
+++ b/web/modules/custom/features/herbie_archive_page/herbie_archive_page.info.yml
@@ -23,6 +23,6 @@ dependencies:
   - 'herbie_media_types:herbie_media_types'
   - 'linkit:linkit'
   - 'pathauto:pathauto'
-version: 1.2.1
+version: 1.2.2
 package: Herbie
 description: 'Provides Temporary transition page (Archive page) content type and related configuration. '

--- a/web/modules/custom/features/herbie_book/config/optional/core.entity_view_display.node.book.default.yml
+++ b/web/modules/custom/features/herbie_book/config/optional/core.entity_view_display.node.book.default.yml
@@ -19,7 +19,13 @@ content:
     third_party_settings: {  }
     weight: 100
     region: content
+  content_moderation_control:
+    settings: {  }
+    third_party_settings: {  }
+    weight: -20
+    region: content
   links:
     weight: 101
     region: content
-hidden: {  }
+hidden:
+  entitygroupfield: true

--- a/web/modules/custom/features/herbie_book/config/optional/core.entity_view_display.node.book.teaser.yml
+++ b/web/modules/custom/features/herbie_book/config/optional/core.entity_view_display.node.book.teaser.yml
@@ -21,7 +21,13 @@ content:
     third_party_settings: {  }
     weight: 100
     region: content
+  content_moderation_control:
+    settings: {  }
+    third_party_settings: {  }
+    weight: -20
+    region: content
   links:
     weight: 101
     region: content
-hidden: {  }
+hidden:
+  entitygroupfield: true

--- a/web/modules/custom/features/herbie_book/herbie_book.info.yml
+++ b/web/modules/custom/features/herbie_book/herbie_book.info.yml
@@ -6,5 +6,5 @@ dependencies:
   - 'drupal:node'
   - 'herbie_webform:herbie_webform'
   - 'pathauto:pathauto'
-version: 1.2.1
+version: 1.2.2
 package: Herbie

--- a/web/modules/custom/features/herbie_builder_page/config/install/core.entity_view_display.node.builder_page.default.yml
+++ b/web/modules/custom/features/herbie_builder_page/config/install/core.entity_view_display.node.builder_page.default.yml
@@ -282,5 +282,6 @@ content:
     weight: 102
     region: first
 hidden:
+  entitygroupfield: true
   layout_builder__layout: true
   s_n_page_options: true

--- a/web/modules/custom/features/herbie_builder_page/config/install/core.entity_view_display.node.builder_page.full.yml
+++ b/web/modules/custom/features/herbie_builder_page/config/install/core.entity_view_display.node.builder_page.full.yml
@@ -178,6 +178,11 @@ content:
     third_party_settings: {  }
     weight: 101
     region: content
+  content_moderation_control:
+    settings: {  }
+    third_party_settings: {  }
+    weight: -20
+    region: content
   links:
     settings: {  }
     third_party_settings: {  }
@@ -193,5 +198,6 @@ content:
     weight: 102
     region: first
 hidden:
+  entitygroupfield: true
   layout_builder__layout: true
   s_n_page_options: true

--- a/web/modules/custom/features/herbie_builder_page/config/install/core.entity_view_display.node.builder_page.teaser.yml
+++ b/web/modules/custom/features/herbie_builder_page/config/install/core.entity_view_display.node.builder_page.teaser.yml
@@ -45,5 +45,6 @@ content:
     weight: 1
     region: content
 hidden:
+  entitygroupfield: true
   layout_builder__layout: true
   s_n_page_options: true

--- a/web/modules/custom/features/herbie_builder_page/herbie_builder_page.info.yml
+++ b/web/modules/custom/features/herbie_builder_page/herbie_builder_page.info.yml
@@ -74,5 +74,5 @@ dependencies:
   - 'unl_news:unl_news'
   - 'webform:webform'
   - 'webform:webform_submission_log'
-version: 1.8.1
+version: 1.8.2
 package: Herbie

--- a/web/modules/custom/features/herbie_group/config/install/group.role.group_subsite-anonymous.yml
+++ b/web/modules/custom/features/herbie_group/config/install/group.role.group_subsite-anonymous.yml
@@ -11,4 +11,13 @@ admin: false
 scope: outsider
 global_role: anonymous
 group_type: group_subsite
-permissions: {  }
+permissions:
+  - 'view group'
+  - 'view group_node:archive_page entity'
+  - 'view group_node:book entity'
+  - 'view group_node:builder_page entity'
+  - 'view group_node:major entity'
+  - 'view group_node:major_option entity'
+  - 'view group_node:news entity'
+  - 'view group_node:person entity'
+  - 'view group_node:webform entity'

--- a/web/modules/custom/features/herbie_group/config/install/group.role.group_subsite-outsider.yml
+++ b/web/modules/custom/features/herbie_group/config/install/group.role.group_subsite-outsider.yml
@@ -11,4 +11,13 @@ admin: false
 scope: outsider
 global_role: authenticated
 group_type: group_subsite
-permissions: {  }
+permissions:
+  - 'view group'
+  - 'view group_node:archive_page entity'
+  - 'view group_node:book entity'
+  - 'view group_node:builder_page entity'
+  - 'view group_node:major entity'
+  - 'view group_node:major_option entity'
+  - 'view group_node:news entity'
+  - 'view group_node:person entity'
+  - 'view group_node:webform entity'

--- a/web/modules/custom/features/herbie_group/herbie_group.info.yml
+++ b/web/modules/custom/features/herbie_group/herbie_group.info.yml
@@ -17,5 +17,5 @@ dependencies:
   - 'herbie_news:herbie_news'
   - 'herbie_person:herbie_person'
   - 'herbie_roles:herbie_roles'
-version: '1.0'
+version: '1.1'
 package: Herbie

--- a/web/modules/custom/features/herbie_major/config/install/core.entity_form_display.node.major.default.yml
+++ b/web/modules/custom/features/herbie_major/config/install/core.entity_form_display.node.major.default.yml
@@ -528,4 +528,5 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
-hidden: {  }
+hidden:
+  entitygroupfield: true

--- a/web/modules/custom/features/herbie_major/config/install/core.entity_form_display.node.major_option.default.yml
+++ b/web/modules/custom/features/herbie_major/config/install/core.entity_form_display.node.major_option.default.yml
@@ -227,4 +227,5 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
-hidden: {  }
+hidden:
+  entitygroupfield: true

--- a/web/modules/custom/features/herbie_major/config/install/core.entity_view_display.node.major.default.yml
+++ b/web/modules/custom/features/herbie_major/config/install/core.entity_view_display.node.major.default.yml
@@ -329,5 +329,6 @@ content:
     weight: 15
     region: content
 hidden:
+  entitygroupfield: true
   n_major_areas_interest: true
   n_major_college_external_url: true

--- a/web/modules/custom/features/herbie_major/config/install/core.entity_view_display.node.major.teaser.yml
+++ b/web/modules/custom/features/herbie_major/config/install/core.entity_view_display.node.major.teaser.yml
@@ -50,6 +50,7 @@ content:
     weight: 100
     region: content
 hidden:
+  entitygroupfield: true
   n_major_4year_link: true
   n_major_academics_experiential: true
   n_major_areas_focus: true

--- a/web/modules/custom/features/herbie_major/config/install/core.entity_view_display.node.major_option.default.yml
+++ b/web/modules/custom/features/herbie_major/config/install/core.entity_view_display.node.major_option.default.yml
@@ -158,4 +158,5 @@ content:
     third_party_settings: {  }
     weight: 2
     region: content
-hidden: {  }
+hidden:
+  entitygroupfield: true

--- a/web/modules/custom/features/herbie_major/config/install/core.entity_view_display.node.major_option.teaser.yml
+++ b/web/modules/custom/features/herbie_major/config/install/core.entity_view_display.node.major_option.teaser.yml
@@ -36,6 +36,7 @@ content:
     weight: 100
     region: content
 hidden:
+  entitygroupfield: true
   n_major_notable_courses: true
   n_major_option_careers_list: true
   n_major_option_careers_title: true

--- a/web/modules/custom/features/herbie_major/herbie_major.info.yml
+++ b/web/modules/custom/features/herbie_major/herbie_major.info.yml
@@ -27,5 +27,5 @@ dependencies:
   - 'pathauto:pathauto'
   - 'svg_image:svg_image'
   - 'twig_ui:twig_ui'
-version: '1.5'
+version: '1.6'
 package: Herbie

--- a/web/modules/custom/features/herbie_news/config/install/core.entity_view_display.node.news.default.yml
+++ b/web/modules/custom/features/herbie_news/config/install/core.entity_view_display.node.news.default.yml
@@ -112,4 +112,5 @@ content:
     third_party_settings: {  }
     weight: 7
     region: content
-hidden: {  }
+hidden:
+  entitygroupfield: true

--- a/web/modules/custom/features/herbie_news/config/install/core.entity_view_display.node.news.teaser.yml
+++ b/web/modules/custom/features/herbie_news/config/install/core.entity_view_display.node.news.teaser.yml
@@ -41,6 +41,7 @@ content:
     region: content
 hidden:
   body: true
+  entitygroupfield: true
   n_news_byline: true
   n_news_canonical_url: true
   n_news_foreign_key: true

--- a/web/modules/custom/features/herbie_news/herbie_news.info.yml
+++ b/web/modules/custom/features/herbie_news/herbie_news.info.yml
@@ -26,5 +26,5 @@ dependencies:
   - 'herbie_webform:herbie_webform'
   - 'image_class:image_class'
   - 'pathauto:pathauto'
-version: 1.4.1
+version: 1.4.2
 package: Herbie

--- a/web/modules/custom/features/herbie_person/config/install/core.entity_form_display.node.person.default.yml
+++ b/web/modules/custom/features/herbie_person/config/install/core.entity_form_display.node.person.default.yml
@@ -87,12 +87,6 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
-  moderation_state:
-    type: moderation_state_default
-    weight: 15
-    region: content
-    settings: {  }
-    third_party_settings: {  }
   entitygroupfield:
     type: entitygroupfield_select_widget
     weight: 15

--- a/web/modules/custom/features/herbie_person/config/install/core.entity_view_display.node.person.default.yml
+++ b/web/modules/custom/features/herbie_person/config/install/core.entity_view_display.node.person.default.yml
@@ -199,4 +199,5 @@ content:
     third_party_settings: {  }
     weight: 5
     region: content
-hidden: {  }
+hidden:
+  entitygroupfield: true

--- a/web/modules/custom/features/herbie_person/config/install/core.entity_view_display.node.person.teaser.yml
+++ b/web/modules/custom/features/herbie_person/config/install/core.entity_view_display.node.person.teaser.yml
@@ -193,4 +193,5 @@ content:
     weight: 17
     region: content
 hidden:
+  entitygroupfield: true
   n_person_affiliation: true

--- a/web/modules/custom/features/herbie_person/config/install/core.entity_view_display.node.person.teaser_centered.yml
+++ b/web/modules/custom/features/herbie_person/config/install/core.entity_view_display.node.person.teaser_centered.yml
@@ -192,4 +192,6 @@ content:
     third_party_settings: {  }
     weight: 5
     region: content
-hidden: {  }
+hidden:
+  entitygroupfield: true
+  n_person_affiliation: true

--- a/web/modules/custom/features/herbie_person/config/install/core.entity_view_display.node.person.teaser_featured.yml
+++ b/web/modules/custom/features/herbie_person/config/install/core.entity_view_display.node.person.teaser_featured.yml
@@ -180,6 +180,7 @@ content:
     weight: 5
     region: content
 hidden:
+  entitygroupfield: true
   n_additional: true
   n_education: true
   n_person_affiliation: true

--- a/web/modules/custom/features/herbie_person/config/install/core.entity_view_display.node.person.teaser_small.yml
+++ b/web/modules/custom/features/herbie_person/config/install/core.entity_view_display.node.person.teaser_small.yml
@@ -180,6 +180,7 @@ content:
     weight: 5
     region: content
 hidden:
+  entitygroupfield: true
   n_additional: true
   n_education: true
   n_person_affiliation: true

--- a/web/modules/custom/features/herbie_person/herbie_person.info.yml
+++ b/web/modules/custom/features/herbie_person/herbie_person.info.yml
@@ -31,5 +31,5 @@ dependencies:
   - 'pathauto:pathauto'
   - 'svg_image:svg_image'
   - 'svg_image:svg_image_responsive'
-version: 1.3.3
+version: 1.3.4
 package: Herbie

--- a/web/modules/custom/features/herbie_webform/config/optional/core.entity_view_display.node.webform.default.yml
+++ b/web/modules/custom/features/herbie_webform/config/optional/core.entity_view_display.node.webform.default.yml
@@ -33,4 +33,5 @@ content:
     third_party_settings: {  }
     weight: 102
     region: content
-hidden: {  }
+hidden:
+  entitygroupfield: true

--- a/web/modules/custom/features/herbie_webform/config/optional/core.entity_view_display.node.webform.teaser.yml
+++ b/web/modules/custom/features/herbie_webform/config/optional/core.entity_view_display.node.webform.teaser.yml
@@ -28,4 +28,5 @@ content:
     weight: 100
     region: content
 hidden:
+  entitygroupfield: true
   webform: true

--- a/web/modules/custom/features/herbie_webform/herbie_webform.info.yml
+++ b/web/modules/custom/features/herbie_webform/herbie_webform.info.yml
@@ -16,5 +16,5 @@ dependencies:
   - 'linkit:linkit'
   - 'pathauto:pathauto'
   - 'webform:webform'
-version: 1.3.1
+version: 1.3.2
 package: Herbie


### PR DESCRIPTION
Closes #754 

Added view permissions for Group nodes to anonymous and authenticated users. Included entity group field installation configurations that were missed during the initial Group release. Removed duplicate moderation state configuration. Fixes 