### PR TITLE
Update media library table view #552

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -156,7 +156,7 @@
         "drupal/entity_reference_revisions": "^1.0",
         "drupal/entity_share": "^3.0@RC",
         "drupal/entity_share_cron": "^3.0",
-        "drupal/entity_usage": "^2.0",
+        "drupal/entity_usage": "^2.0@beta",
         "drupal/entitygroupfield": "^2.0@alpha",
         "drupal/external_entities": "2.x-dev@dev",
         "drupal/features": "5.0.x-dev@dev",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "654bd8845300ce0693a0247f3fe1632f",
+    "content-hash": "fd6cae94c80b6dc1f19c964bef6ad32d",
     "packages": [
         {
             "name": "arthurkushman/query-path",
@@ -3151,17 +3151,17 @@
         },
         {
             "name": "drupal/entity_usage",
-            "version": "2.0.0-beta11",
+            "version": "2.0.0-beta12",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/entity_usage.git",
-                "reference": "8.x-2.0-beta11"
+                "reference": "8.x-2.0-beta12"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/entity_usage-8.x-2.0-beta11.zip",
-                "reference": "8.x-2.0-beta11",
-                "shasum": "31b7248887c917a5aa85bb0c8251467b96d53110"
+                "url": "https://ftp.drupal.org/files/projects/entity_usage-8.x-2.0-beta12.zip",
+                "reference": "8.x-2.0-beta12",
+                "shasum": "cdd31e6c413cad6fbdb1bd0aac9ad8a0331eb429"
             },
             "require": {
                 "drupal/core": "^9.1 || ^10"
@@ -3181,8 +3181,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-2.0-beta11",
-                    "datestamp": "1676966168",
+                    "version": "8.x-2.0-beta12",
+                    "datestamp": "1684309054",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Beta releases are not covered by Drupal security advisories."
@@ -3199,6 +3199,10 @@
                 "GPL-2.0+"
             ],
             "authors": [
+                {
+                    "name": "Lullabot",
+                    "homepage": "https://www.drupal.org/user/3815489"
+                },
                 {
                     "name": "marcoscano",
                     "homepage": "https://www.drupal.org/user/1288796"
@@ -17741,6 +17745,7 @@
         "drupal/config_update": 15,
         "drupal/default_content": 15,
         "drupal/entity_share": 5,
+        "drupal/entity_usage": 10,
         "drupal/entitygroupfield": 15,
         "drupal/external_entities": 20,
         "drupal/features": 20,

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -159,6 +159,7 @@ module:
   unl_cas: 0
   unl_config: 0
   unl_contenthub: 0
+  unl_entity_usage: 0
   unl_events: 0
   unl_feeds: 0
   unl_group: 0

--- a/config/sync/entity_usage.settings.yml
+++ b/config/sync/entity_usage.settings.yml
@@ -12,6 +12,7 @@ track_enabled_plugins:
   - media_embed
   - linkit
   - layout_builder
+  - entity_reference
 track_enabled_base_fields: false
 site_domains: {  }
 edit_warning_message_entity_types:

--- a/config/sync/views.view.media.yml
+++ b/config/sync/views.view.media.yml
@@ -7,8 +7,8 @@ dependencies:
     - taxonomy.vocabulary.media_tags
   module:
     - entity_usage
-    - image
     - media
+    - svg_image
     - taxonomy
     - user
 _core:
@@ -206,7 +206,7 @@ display:
             image_style: thumbnail
             image_loading:
               attribute: lazy
-          group_column: ''
+          group_column: entity_id
           group_columns: {  }
           group_rows: true
           delta_limit: 0
@@ -465,14 +465,14 @@ display:
           table: entity_usage
           field: count
           relationship: media_to_usage_entity
-          group_type: group
+          group_type: sum
           admin_label: ''
           plugin_id: numeric
-          label: 'Used in'
+          label: 'Referenced in Content '
           exclude: false
           alter:
-            alter_text: false
-            text: ''
+            alter_text: true
+            text: 'Yes'
             make_link: true
             path: 'media/{{ mid }}/usage'
             absolute: false
@@ -505,16 +505,16 @@ display:
           element_wrapper_type: ''
           element_wrapper_class: ''
           element_default_classes: true
-          empty: ''
+          empty: 'No (Clear cache to double-check new changes)'
           hide_empty: false
-          empty_zero: false
+          empty_zero: true
           hide_alter_empty: true
           set_precision: false
           precision: 0
           decimal: .
           separator: ','
-          format_plural: true
-          format_plural_string: !!binary MSBwbGFjZQNAY291bnQgcGxhY2Vz
+          format_plural: false
+          format_plural_string: !!binary VHJ1ZQNUcnVl
           prefix: ''
           suffix: ''
         operations:
@@ -886,6 +886,7 @@ display:
           entity_type: media
           plugin_id: standard
           required: false
+      group_by: true
       header: {  }
       footer: {  }
       display_extenders: {  }

--- a/web/modules/custom/features/herbie_config/config/install/entity_usage.settings.yml
+++ b/web/modules/custom/features/herbie_config/config/install/entity_usage.settings.yml
@@ -1,0 +1,20 @@
+local_task_enabled_entity_types:
+  - media
+track_enabled_source_entity_types:
+  - block_content
+  - node
+  - paragraph
+track_enabled_target_entity_types:
+  - media
+track_enabled_plugins:
+  - media_embed
+  - linkit
+  - layout_builder
+  - entity_reference
+track_enabled_base_fields: false
+site_domains: {  }
+edit_warning_message_entity_types:
+  - media
+delete_warning_message_entity_types:
+  - media
+usage_controller_items_per_page: 25

--- a/web/modules/custom/features/herbie_config/herbie_config.features.yml
+++ b/web/modules/custom/features/herbie_config/herbie_config.features.yml
@@ -2,3 +2,4 @@ bundle: herbie
 required:
   - unl_five.settings
   - unl_five_herbie.settings
+  - entity_usage.settings

--- a/web/modules/custom/features/herbie_config/herbie_config.info.yml
+++ b/web/modules/custom/features/herbie_config/herbie_config.info.yml
@@ -2,7 +2,8 @@ name: 'Herbie config'
 description: 'A bundle of miscellaneous configuration files, mainly to override default configuration in modules or other settings. '
 type: module
 core_version_requirement: '^9.4 || ^10'
-version: 1.1
+version: '1.2'
 package: Herbie
 dependencies:
+  - 'entity_usage:entity_usage'
   - 'replicate_ui:replicate_ui'

--- a/web/modules/custom/features/herbie_media_types/config/optional/views.view.media.yml
+++ b/web/modules/custom/features/herbie_media_types/config/optional/views.view.media.yml
@@ -6,8 +6,8 @@ dependencies:
     - taxonomy.vocabulary.media_tags
   module:
     - entity_usage
-    - image
     - media
+    - svg_image
     - taxonomy
     - user
 id: media
@@ -203,7 +203,7 @@ display:
             image_style: thumbnail
             image_loading:
               attribute: lazy
-          group_column: ''
+          group_column: entity_id
           group_columns: {  }
           group_rows: true
           delta_limit: 0
@@ -462,14 +462,14 @@ display:
           table: entity_usage
           field: count
           relationship: media_to_usage_entity
-          group_type: group
+          group_type: sum
           admin_label: ''
           plugin_id: numeric
-          label: 'Used in'
+          label: 'Referenced in Content '
           exclude: false
           alter:
-            alter_text: false
-            text: ''
+            alter_text: true
+            text: 'Yes'
             make_link: true
             path: 'media/{{ mid }}/usage'
             absolute: false
@@ -502,16 +502,16 @@ display:
           element_wrapper_type: ''
           element_wrapper_class: ''
           element_default_classes: true
-          empty: ''
+          empty: 'No (Clear cache to double-check new changes)'
           hide_empty: false
-          empty_zero: false
+          empty_zero: true
           hide_alter_empty: true
           set_precision: false
           precision: 0
           decimal: .
           separator: ','
-          format_plural: true
-          format_plural_string: !!binary MSBwbGFjZQNAY291bnQgcGxhY2Vz
+          format_plural: false
+          format_plural_string: !!binary VHJ1ZQNUcnVl
           prefix: ''
           suffix: ''
         operations:
@@ -883,6 +883,7 @@ display:
           entity_type: media
           plugin_id: standard
           required: false
+      group_by: true
       header: {  }
       footer: {  }
       display_extenders: {  }

--- a/web/modules/custom/features/herbie_media_types/herbie_media_types.info.yml
+++ b/web/modules/custom/features/herbie_media_types/herbie_media_types.info.yml
@@ -48,5 +48,5 @@ dependencies:
   - 'twig_ui:twig_ui'
   - 'unl_config:unl_config'
   - 'webform:webform'
-version: 2.1.2
+version: 2.1.3
 package: Herbie


### PR DESCRIPTION
Closes #552 

* Batch updates must be run on all sites for the new entity configuration settings to take effect. I have been using the Batch Update menu item found under the Entity Usage settings, but I believe there is also a Drush command available for this.

<img width="776" alt="image" src="https://github.com/user-attachments/assets/36c8b2ad-3504-4497-9d96-d45b8130969d">


Issues fixed:

- Images in blocks can now be tracked.
- Multiple rows of the same media item referenced in the media view have been eliminated.
- The media view now indicates whether a media item is being used.

Issues that still exist:

The Entity Usage module currently has a behavior where every time a node or block is saved, it creates a new instance of tracking for the media item, even if no changes were made. The issue can be found in the entity_usage/src/EntityUsageTrackBase.php file. <img width="681" alt="image" src="https://github.com/user-attachments/assets/13e6b8cf-88ca-47b4-8c5f-46f4e5d7ede4"> We can modify the function to change this behavior if desired. We can change the code to avoid relying on revision IDs, given that each edit action and a default "Save" button click will result in a new revision ID.

When a component containing a media item is created, the media view does not immediately reflect the change. This also occurs when the component is deleted. A cache clear or a cron job needs to be run for the changes to appear. We can try disabling the view's cache using views_post_update if that is the preferred approach.

