### PR TITLE
Web audit errors fix 788

### DIFF
--- a/web/themes/custom/unl_five_herbie/templates/node/node--person--full.html.twig
+++ b/web/themes/custom/unl_five_herbie/templates/node/node--person--full.html.twig
@@ -42,7 +42,7 @@
 
                 <p class="dcf-lh-3 dcf-mt-2 dcf-italic" itemprop="jobTitle">
                   {% if node.n_person_position.value %}
-                    {{ content.n_person_position }}
+                    {{node.n_person_position.value}}
                   {% else %}
                     {{ node.n_person_unldirectoryreference.entity.ee_unldir_title.value }}
                   {% endif %}

--- a/web/themes/custom/unl_five_herbie/templates/node/node--person--teaser-centered.html.twig
+++ b/web/themes/custom/unl_five_herbie/templates/node/node--person--teaser-centered.html.twig
@@ -34,7 +34,7 @@
             <div class="dcf-lh-3 dcf-txt-sm dcf-italic">
               <span itemprop="jobTitle">
                 {% if node.n_person_position.value %}
-                  {{ content.n_person_position }}
+                  {{node.n_person_position.value}}
                 {% else %}
                   {{ node.n_person_unldirectoryreference.entity.ee_unldir_title.value }}
                 {% endif %}

--- a/web/themes/custom/unl_five_herbie/templates/node/node--person--teaser-featured.html.twig
+++ b/web/themes/custom/unl_five_herbie/templates/node/node--person--teaser-featured.html.twig
@@ -27,7 +27,7 @@
       {{ title_suffix }}
       <div class="dcf-lh-3 dcf-txt-sm dcf-italic" itemprop="jobTitle">
         {% if node.n_person_position.value %}
-          {{ content.n_person_position }}
+          {{node.n_person_position.value}}
         {% else %}
           {{ node.n_person_unldirectoryreference.entity.ee_unldir_title.value }}
         {% endif %}
@@ -35,13 +35,11 @@
 
       {% if node.n_person_bio.value is not empty or node.n_person_unldirectoryreference.entity.ee_unldir_knowledge_bio.value is not iterable %}
         <div class="dcf-mt-4">
-          <p>
             {% if node.n_person_bio.value is not empty %}
               {{ content.n_person_bio }}
             {% else %}
               {{ node.n_person_unldirectoryreference.entity.ee_unldir_knowledge_bio.value }}
             {% endif %}
-          </p>
         </div>
       {% endif %}
     </div>

--- a/web/themes/custom/unl_five_herbie/templates/node/node--person--teaser-small.html.twig
+++ b/web/themes/custom/unl_five_herbie/templates/node/node--person--teaser-small.html.twig
@@ -25,7 +25,7 @@
 
       <div class="dcf-lh-3 dcf-txt-xs dcf-italic" itemprop="jobTitle">
         {% if node.n_person_position.value %}
-          {{ content.n_person_position }}
+          {{node.n_person_position.value}}
         {% else %}
           {{ node.n_person_unldirectoryreference.entity.ee_unldir_title.value }}
         {% endif %}

--- a/web/themes/custom/unl_five_herbie/templates/node/node--person--teaser.html.twig
+++ b/web/themes/custom/unl_five_herbie/templates/node/node--person--teaser.html.twig
@@ -37,7 +37,7 @@
           <div class="dcf-lh-3 dcf-txt-sm dcf-italic">
             <span itemprop="jobTitle">
               {% if node.n_person_position.value %}
-                {{ content.n_person_position }}
+                {{node.n_person_position.value}}
               {% else %}
                 {{ node.n_person_unldirectoryreference.entity.ee_unldir_title.value }}
               {% endif %}

--- a/web/themes/custom/unl_five_herbie/templates/node/node--person--teaser.html.twig
+++ b/web/themes/custom/unl_five_herbie/templates/node/node--person--teaser.html.twig
@@ -62,11 +62,10 @@
 
           {# Address #}
           <address class="dcf-mt-4">
+           <span class="type dcf-d-none">Work</span>
            <dl class="dcf-txt-sm dcf-mb-0">
               {% if node.n_person_address[0].value or node.n_person_unldirectoryreference.entity.ee_unldir_unldirectoryaddress[0].value %}
-                <span class="type dcf-d-none">Work</span>
                 <dt class="dcf-sr-only">Address</dt>
-
                 <dd class="dcf-d-flex dcf-col-gap-2">
                   <div class="dcf-h-4 dcf-w-4 unl-gray dcf-mt-1">
                     <svg class="dcf-h-100% dcf-w-100% dcf-fill-current" focusable="false" height="16" width="16" viewbox="0 0 24 24" aria-hidden="true">

--- a/web/themes/custom/unl_five_herbie/unl_five_herbie.theme
+++ b/web/themes/custom/unl_five_herbie/unl_five_herbie.theme
@@ -77,6 +77,12 @@ function unl_five_herbie_preprocess_block(&$variables) {
     $bundle = $variables['content']['#block_content']->bundle();
   }
 
+  if($variables['plugin_id'] == 'menu_block:main') {
+    // Generate a unique ID for the block.
+    $unique_id = uniqid('menu-block-main-', FALSE);
+    $variables['attributes']['id'] = $unique_id;
+  }
+
   if (isset($variables['content']['#block_content'])) {
     $section_layout_builder_styles = $variables['content']['#block_content']->__get('#section_lbs');
     $variables['data']['section_lbs'] = $section_layout_builder_styles;


### PR DESCRIPTION
Closes #788 

The ID attribute for the menu block was previously set to -menu. When including Node Include contents on a page, web audit identified multiple menu blocks with the same ID. To resolve this, I have appended a unique ID to the existing ID to ensure that each menu block has a distinct identifier.

