### PR TITLE
Contact block for groups 790

### DIFF
--- a/config/sync/block.block.views_block__group_contact_info_block.yml
+++ b/config/sync/block.block.views_block__group_contact_info_block.yml
@@ -1,0 +1,25 @@
+uuid: d2ad1453-0ac6-4c41-8f8f-5250e7d8c331
+langcode: en
+status: true
+dependencies:
+  config:
+    - views.view.group_contact_info_block
+  module:
+    - views
+  theme:
+    - unl_five_herbie
+id: views_block__group_contact_info_block
+theme: unl_five_herbie
+region: contactinfo
+weight: 0
+provider: null
+plugin: 'views_block:group_contact_info_block-block_1'
+settings:
+  id: 'views_block:group_contact_info_block-block_1'
+  label: ''
+  label_display: visible
+  provider: views
+  context_mapping: {  }
+  views_label: ''
+  items_per_page: none
+visibility: {  }

--- a/config/sync/core.entity_form_display.group.group_subsite.default.yml
+++ b/config/sync/core.entity_form_display.group.group_subsite.default.yml
@@ -4,11 +4,11 @@ status: true
 dependencies:
   config:
     - field.field.group.group_subsite.group_subsite_contact_info_block
+    - field.field.group.group_subsite.group_subsite_group_affiliation
     - field.field.group.group_subsite.group_subsite_node_reference
     - group.type.group_subsite
   module:
     - inline_entity_form
-    - link
     - path
 _core:
   default_config_hash: UQQvqGuooqrzRxw3aLY_Gubd2GfbXnK9B38Cb_6xyl0
@@ -29,13 +29,6 @@ content:
       collapsible: false
       collapsed: false
       revision: false
-  group_subsite_group_affiliation:
-    type: link_default
-    weight: 2
-    region: content
-    settings:
-      placeholder_url: ''
-      placeholder_title: ''
     third_party_settings: {  }
   group_subsite_node_reference:
     type: entity_reference_autocomplete
@@ -57,16 +50,17 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 3
+    weight: 2
     region: content
     settings: {  }
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 4
+    weight: 3
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
 hidden:
+  group_subsite_group_affiliation: true
   uid: true

--- a/config/sync/core.entity_form_display.group.group_subsite.default.yml
+++ b/config/sync/core.entity_form_display.group.group_subsite.default.yml
@@ -8,10 +8,6 @@ dependencies:
     - group.type.group_subsite
   module:
     - inline_entity_form
-    - field.field.group.group_subsite.group_subsite_group_affiliation
-    - field.field.group.group_subsite.group_subsite_node_reference
-    - group.type.group_subsite
-  module:
     - link
     - path
 _core:

--- a/config/sync/core.entity_form_display.group.group_subsite.default.yml
+++ b/config/sync/core.entity_form_display.group.group_subsite.default.yml
@@ -3,9 +3,11 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.group.group_subsite.group_subsite_contact_info_block
     - field.field.group.group_subsite.group_subsite_node_reference
     - group.type.group_subsite
   module:
+    - inline_entity_form
     - path
 _core:
   default_config_hash: UQQvqGuooqrzRxw3aLY_Gubd2GfbXnK9B38Cb_6xyl0
@@ -14,6 +16,19 @@ targetEntityType: group
 bundle: group_subsite
 mode: default
 content:
+  group_subsite_contact_info_block:
+    type: inline_entity_form_simple
+    weight: 26
+    region: content
+    settings:
+      form_mode: default
+      override_labels: false
+      label_singular: ''
+      label_plural: ''
+      collapsible: false
+      collapsed: false
+      revision: false
+    third_party_settings: {  }
   group_subsite_node_reference:
     type: entity_reference_autocomplete
     weight: 1

--- a/config/sync/core.entity_view_display.group.group_subsite.default.yml
+++ b/config/sync/core.entity_view_display.group.group_subsite.default.yml
@@ -14,15 +14,6 @@ targetEntityType: group
 bundle: group_subsite
 mode: default
 content:
-  group_subsite_contact_info_block:
-    type: entity_reference_entity_view
-    label: hidden
-    settings:
-      view_mode: default
-      link: false
-    third_party_settings: {  }
-    weight: -3
-    region: content
   group_subsite_node_reference:
     type: entity_reference_entity_view
     label: hidden
@@ -43,5 +34,6 @@ content:
 hidden:
   changed: true
   created: true
+  group_subsite_contact_info_block: true
   group_subsite_group_affiliation: true
   uid: true

--- a/config/sync/core.entity_view_display.group.group_subsite.default.yml
+++ b/config/sync/core.entity_view_display.group.group_subsite.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.group.group_subsite.group_subsite_contact_info_block
     - field.field.group.group_subsite.group_subsite_node_reference
     - group.type.group_subsite
 _core:
@@ -12,6 +13,15 @@ targetEntityType: group
 bundle: group_subsite
 mode: default
 content:
+  group_subsite_contact_info_block:
+    type: entity_reference_entity_view
+    label: hidden
+    settings:
+      view_mode: default
+      link: false
+    third_party_settings: {  }
+    weight: -3
+    region: content
   group_subsite_node_reference:
     type: entity_reference_entity_view
     label: hidden

--- a/config/sync/field.field.group.group_subsite.group_subsite_contact_info_block.yml
+++ b/config/sync/field.field.group.group_subsite.group_subsite_contact_info_block.yml
@@ -1,0 +1,29 @@
+uuid: c4372e6a-f6f3-4be0-a052-2acc1df058ec
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.contact_info
+    - field.storage.group.group_subsite_contact_info_block
+    - group.type.group_subsite
+id: group.group_subsite.group_subsite_contact_info_block
+field_name: group_subsite_contact_info_block
+entity_type: group
+bundle: group_subsite
+label: 'Subsite contact info block'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:block_content'
+  handler_settings:
+    target_bundles:
+      contact_info: contact_info
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.storage.group.group_subsite_contact_info_block.yml
+++ b/config/sync/field.storage.group.group_subsite_contact_info_block.yml
@@ -1,0 +1,20 @@
+uuid: 05750b1d-ad81-470a-b5ee-f9ad9c2dae91
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+    - group
+id: group.group_subsite_contact_info_block
+field_name: group_subsite_contact_info_block
+entity_type: group
+type: entity_reference
+settings:
+  target_type: block_content
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/views.view.group_contact_info_block.yml
+++ b/config/sync/views.view.group_contact_info_block.yml
@@ -1,0 +1,232 @@
+uuid: 1d97bec2-2559-45d2-a9d7-3972e062f5a9
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.contact_info
+  module:
+    - block_content
+    - group
+    - user
+id: group_contact_info_block
+label: 'Group Contact Info Block'
+module: views
+description: ''
+tag: ''
+base_table: block_content_field_data
+base_field: id
+display:
+  default:
+    id: default
+    display_title: Default
+    display_plugin: default
+    position: 0
+    display_options:
+      title: 'Contact us'
+      fields:
+        info:
+          id: info
+          table: block_content_field_data
+          field: info
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: info
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+      pager:
+        type: some
+        options:
+          offset: 0
+          items_per_page: 0
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      empty: {  }
+      sorts: {  }
+      arguments:
+        id:
+          id: id
+          table: groups_field_data
+          field: id
+          relationship: reverse__group__group_subsite_contact_info_block
+          group_type: group
+          admin_label: ''
+          entity_type: group
+          entity_field: id
+          plugin_id: group_id
+          default_action: default
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: group_id_from_url
+          default_argument_options: {  }
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            override: false
+            items_per_page: 25
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          break_phrase: false
+          not: false
+      filters:
+        status:
+          id: status
+          table: block_content_field_data
+          field: status
+          entity_type: block_content
+          entity_field: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
+          expose:
+            operator: ''
+        reusable:
+          id: reusable
+          table: block_content_field_data
+          field: reusable
+          entity_type: block_content
+          entity_field: reusable
+          plugin_id: boolean
+          value: '1'
+        type:
+          id: type
+          table: block_content_field_data
+          field: type
+          entity_type: block_content
+          entity_field: type
+          plugin_id: bundle
+          value:
+            contact_info: contact_info
+      style:
+        type: default
+      row:
+        type: 'entity:block_content'
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships:
+        reverse__group__group_subsite_contact_info_block:
+          id: reverse__group__group_subsite_contact_info_block
+          table: block_content_field_data
+          field: reverse__group__group_subsite_contact_info_block
+          relationship: none
+          group_type: group
+          admin_label: group_subsite_contact_info_block
+          entity_type: block_content
+          plugin_id: entity_reverse
+          required: false
+      header: {  }
+      footer: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - route
+        - url
+        - user.permissions
+      tags: {  }
+  block_1:
+    id: block_1
+    display_title: Block
+    display_plugin: block
+    position: 1
+    display_options:
+      display_extenders: {  }
+      block_description: 'Group contact info block'
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - route
+        - url
+        - user.permissions
+      tags: {  }

--- a/web/modules/custom/features/herbie_group/config/install/block.block.views_block__group_contact_info_block.yml
+++ b/web/modules/custom/features/herbie_group/config/install/block.block.views_block__group_contact_info_block.yml
@@ -1,0 +1,24 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - views.view.group_contact_info_block
+  module:
+    - views
+  theme:
+    - unl_five_herbie
+id: views_block__group_contact_info_block
+theme: unl_five_herbie
+region: contactinfo
+weight: 0
+provider: null
+plugin: 'views_block:group_contact_info_block-block_1'
+settings:
+  id: 'views_block:group_contact_info_block-block_1'
+  label: ''
+  label_display: visible
+  provider: views
+  context_mapping: {  }
+  views_label: ''
+  items_per_page: none
+visibility: {  }

--- a/web/modules/custom/features/herbie_group/config/install/core.entity_form_display.group.group_subsite.default.yml
+++ b/web/modules/custom/features/herbie_group/config/install/core.entity_form_display.group.group_subsite.default.yml
@@ -7,10 +7,6 @@ dependencies:
     - group.type.group_subsite
   module:
     - inline_entity_form
-    - field.field.group.group_subsite.group_subsite_group_affiliation
-    - field.field.group.group_subsite.group_subsite_node_reference
-    - group.type.group_subsite
-  module:
     - link
     - path
 id: group.group_subsite.default

--- a/web/modules/custom/features/herbie_group/config/install/core.entity_form_display.group.group_subsite.default.yml
+++ b/web/modules/custom/features/herbie_group/config/install/core.entity_form_display.group.group_subsite.default.yml
@@ -2,15 +2,30 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.group.group_subsite.group_subsite_contact_info_block
     - field.field.group.group_subsite.group_subsite_node_reference
     - group.type.group_subsite
   module:
+    - inline_entity_form
     - path
 id: group.group_subsite.default
 targetEntityType: group
 bundle: group_subsite
 mode: default
 content:
+  group_subsite_contact_info_block:
+    type: inline_entity_form_simple
+    weight: 26
+    region: content
+    settings:
+      form_mode: default
+      override_labels: false
+      label_singular: ''
+      label_plural: ''
+      collapsible: false
+      collapsed: false
+      revision: false
+    third_party_settings: {  }
   group_subsite_node_reference:
     type: entity_reference_autocomplete
     weight: 1

--- a/web/modules/custom/features/herbie_group/config/install/core.entity_form_display.group.group_subsite.default.yml
+++ b/web/modules/custom/features/herbie_group/config/install/core.entity_form_display.group.group_subsite.default.yml
@@ -3,11 +3,11 @@ status: true
 dependencies:
   config:
     - field.field.group.group_subsite.group_subsite_contact_info_block
+    - field.field.group.group_subsite.group_subsite_group_affiliation
     - field.field.group.group_subsite.group_subsite_node_reference
     - group.type.group_subsite
   module:
     - inline_entity_form
-    - link
     - path
 id: group.group_subsite.default
 targetEntityType: group
@@ -26,13 +26,6 @@ content:
       collapsible: false
       collapsed: false
       revision: false
-  group_subsite_group_affiliation:
-    type: link_default
-    weight: 2
-    region: content
-    settings:
-      placeholder_url: ''
-      placeholder_title: ''
     third_party_settings: {  }
   group_subsite_node_reference:
     type: entity_reference_autocomplete
@@ -54,16 +47,17 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 3
+    weight: 2
     region: content
     settings: {  }
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 4
+    weight: 3
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
 hidden:
+  group_subsite_group_affiliation: true
   uid: true

--- a/web/modules/custom/features/herbie_group/config/install/core.entity_view_display.group.group_subsite.default.yml
+++ b/web/modules/custom/features/herbie_group/config/install/core.entity_view_display.group.group_subsite.default.yml
@@ -11,15 +11,6 @@ targetEntityType: group
 bundle: group_subsite
 mode: default
 content:
-  group_subsite_contact_info_block:
-    type: entity_reference_entity_view
-    label: hidden
-    settings:
-      view_mode: default
-      link: false
-    third_party_settings: {  }
-    weight: -3
-    region: content
   group_subsite_node_reference:
     type: entity_reference_entity_view
     label: hidden
@@ -40,5 +31,6 @@ content:
 hidden:
   changed: true
   created: true
+  group_subsite_contact_info_block: true
   group_subsite_group_affiliation: true
   uid: true

--- a/web/modules/custom/features/herbie_group/config/install/core.entity_view_display.group.group_subsite.default.yml
+++ b/web/modules/custom/features/herbie_group/config/install/core.entity_view_display.group.group_subsite.default.yml
@@ -2,6 +2,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.group.group_subsite.group_subsite_contact_info_block
     - field.field.group.group_subsite.group_subsite_node_reference
     - group.type.group_subsite
 id: group.group_subsite.default
@@ -9,6 +10,15 @@ targetEntityType: group
 bundle: group_subsite
 mode: default
 content:
+  group_subsite_contact_info_block:
+    type: entity_reference_entity_view
+    label: hidden
+    settings:
+      view_mode: default
+      link: false
+    third_party_settings: {  }
+    weight: -3
+    region: content
   group_subsite_node_reference:
     type: entity_reference_entity_view
     label: hidden

--- a/web/modules/custom/features/herbie_group/config/install/field.field.group.group_subsite.group_subsite_contact_info_block.yml
+++ b/web/modules/custom/features/herbie_group/config/install/field.field.group.group_subsite.group_subsite_contact_info_block.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.contact_info
+    - field.storage.group.group_subsite_contact_info_block
+    - group.type.group_subsite
+id: group.group_subsite.group_subsite_contact_info_block
+field_name: group_subsite_contact_info_block
+entity_type: group
+bundle: group_subsite
+label: 'Subsite contact info block'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:block_content'
+  handler_settings:
+    target_bundles:
+      contact_info: contact_info
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/web/modules/custom/features/herbie_group/config/install/field.storage.group.group_subsite_contact_info_block.yml
+++ b/web/modules/custom/features/herbie_group/config/install/field.storage.group.group_subsite_contact_info_block.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+    - group
+id: group.group_subsite_contact_info_block
+field_name: group_subsite_contact_info_block
+entity_type: group
+type: entity_reference
+settings:
+  target_type: block_content
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/modules/custom/features/herbie_group/config/install/views.view.group_contact_info_block.yml
+++ b/web/modules/custom/features/herbie_group/config/install/views.view.group_contact_info_block.yml
@@ -1,0 +1,231 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.contact_info
+  module:
+    - block_content
+    - group
+    - user
+id: group_contact_info_block
+label: 'Group Contact Info Block'
+module: views
+description: ''
+tag: ''
+base_table: block_content_field_data
+base_field: id
+display:
+  default:
+    id: default
+    display_title: Default
+    display_plugin: default
+    position: 0
+    display_options:
+      title: 'Contact us'
+      fields:
+        info:
+          id: info
+          table: block_content_field_data
+          field: info
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: info
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+      pager:
+        type: some
+        options:
+          offset: 0
+          items_per_page: 0
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      empty: {  }
+      sorts: {  }
+      arguments:
+        id:
+          id: id
+          table: groups_field_data
+          field: id
+          relationship: reverse__group__group_subsite_contact_info_block
+          group_type: group
+          admin_label: ''
+          entity_type: group
+          entity_field: id
+          plugin_id: group_id
+          default_action: default
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: group_id_from_url
+          default_argument_options: {  }
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            override: false
+            items_per_page: 25
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          break_phrase: false
+          not: false
+      filters:
+        status:
+          id: status
+          table: block_content_field_data
+          field: status
+          entity_type: block_content
+          entity_field: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
+          expose:
+            operator: ''
+        reusable:
+          id: reusable
+          table: block_content_field_data
+          field: reusable
+          entity_type: block_content
+          entity_field: reusable
+          plugin_id: boolean
+          value: '1'
+        type:
+          id: type
+          table: block_content_field_data
+          field: type
+          entity_type: block_content
+          entity_field: type
+          plugin_id: bundle
+          value:
+            contact_info: contact_info
+      style:
+        type: default
+      row:
+        type: 'entity:block_content'
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships:
+        reverse__group__group_subsite_contact_info_block:
+          id: reverse__group__group_subsite_contact_info_block
+          table: block_content_field_data
+          field: reverse__group__group_subsite_contact_info_block
+          relationship: none
+          group_type: group
+          admin_label: group_subsite_contact_info_block
+          entity_type: block_content
+          plugin_id: entity_reverse
+          required: false
+      header: {  }
+      footer: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - route
+        - url
+        - user.permissions
+      tags: {  }
+  block_1:
+    id: block_1
+    display_title: Block
+    display_plugin: block
+    position: 1
+    display_options:
+      display_extenders: {  }
+      block_description: 'Group contact info block'
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - route
+        - url
+        - user.permissions
+      tags: {  }

--- a/web/modules/custom/features/herbie_group/herbie_group.info.yml
+++ b/web/modules/custom/features/herbie_group/herbie_group.info.yml
@@ -22,5 +22,5 @@ dependencies:
   - 'herbie_person:herbie_person'
   - 'herbie_roles:herbie_roles'
   - 'inline_entity_form:inline_entity_form'
-version: 1.0.3
+version: 1.0.4
 package: Herbie

--- a/web/modules/custom/features/herbie_group/herbie_group.info.yml
+++ b/web/modules/custom/features/herbie_group/herbie_group.info.yml
@@ -4,10 +4,13 @@ type: module
 core_version_requirement: '^9.4 || ^10'
 dependencies:
   - 'drupal:block'
+  - 'drupal:block_content'
   - 'drupal:field'
   - 'drupal:node'
   - 'drupal:path'
   - 'drupal:user'
+  - 'drupal:views'
+  - 'entity_usage:entity_usage'
   - 'group:gnode'
   - 'group:group'
   - 'group_content_menu:group_content_menu'
@@ -17,5 +20,6 @@ dependencies:
   - 'herbie_news:herbie_news'
   - 'herbie_person:herbie_person'
   - 'herbie_roles:herbie_roles'
-version: 1.0.1
+  - 'inline_entity_form:inline_entity_form'
+version: 1.0.2
 package: Herbie

--- a/web/themes/custom/unl_five_herbie/templates/block/block--block-content-contact-info.html.twig
+++ b/web/themes/custom/unl_five_herbie/templates/block/block--block-content-contact-info.html.twig
@@ -26,6 +26,8 @@
  */
 #}
 
+{% if not hide_block %}
+
 <div{{ attributes }}>
 
   {{ title_prefix }}
@@ -50,3 +52,4 @@
     </div>
   {% endblock %}
 </div>
+{% endif %}

--- a/web/themes/custom/unl_five_herbie/unl_five_herbie.theme
+++ b/web/themes/custom/unl_five_herbie/unl_five_herbie.theme
@@ -61,6 +61,14 @@ function unl_five_herbie_preprocess_region(&$variables) {
       }
     }
   }
+
+  // $group = _unl_five_get_current_group();
+
+  // if ($group) {
+  //   if($variables['elements']['#id'] == 'unl_five_herbie_contactinfo') {
+  //     $variables['hide_block'] = TRUE;
+  //   }
+  // }
 }
 
 /*
@@ -97,6 +105,13 @@ function unl_five_herbie_preprocess_block(&$variables) {
   // Make host available to contact_info custom block.
   if ($bundle == 'contact_info') {
     $variables['data']['host'] = \Drupal::request()->getHost();
+    $group = _unl_five_get_current_group();
+
+   if ($group) {
+     if($variables['elements']['#id'] == 'unl_five_herbie_contactinfo') {
+      $variables['hide_block'] = TRUE;
+     }
+   }
   }
 
   // Make section Layout Builder Block Styles array available to each block in the layout.
@@ -677,3 +692,35 @@ function unl_five_herbie_preprocess_image(&$variables) {
     $variables['attributes']['src'] = $file_url_generator->generateAbsoluteString($variables['uri']);
   }
 }
+
+/**
+ * Get the current Group.
+ *
+ * @return Drupal\group\Entity\Group
+ */
+// function _unl_five_get_current_group() {
+//   $moduleHandler = \Drupal::service('module_handler');
+//   if (!$moduleHandler->moduleExists('group')) {
+//     return NULL;
+//   }
+
+//   // If we're on a Group entity page.
+//   $group_route_context = \Drupal::service('group.group_route_context');
+//   $contexts = $group_route_context->getRuntimeContexts(['group']);
+//   $group = $contexts['group']->getContextValue();
+
+//   // If we're on a Node entity page.
+//   $node = \Drupal::request()->attributes->get('node');
+//   if ($node) {
+//     if (is_numeric($node)) {
+//       $node = Node::load($node);
+//     }
+//     $group_content_array = GroupRelationship::loadByEntity($node);
+//     foreach ($group_content_array as $group_content) {
+//       $group = $group_content->getGroup();
+//     }
+//   }
+
+//   return $group;
+// }
+


### PR DESCRIPTION
Closes #790 

I believe there was a file missing under the config/sync folder when I did a drush config export. I went over to the configuration settings and did a an export of that specific file and added it to the the config sync folder manually. Not sure if it's okay to do this or not. 
![image](https://github.com/user-attachments/assets/a484c54f-6c16-452c-9d26-524eff8c5e42)
config/sync/block.block.views_block__group_contact_info_block.yml

Configuration type
Block
Configuration name
Group contact info block (views_block__group_contact_info_block)
