### PR TITLE
Permanent fix for strnatcasecmp()warning logs reported on some sites. Fixes #868.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -323,7 +323,8 @@
                 "2897377 - data-drupal-selector is set to random value": "patches/2897377-37.patch",
                 "Custom (gh#366) - ProxySQL bug sidestep: don't release savepoints during site install": "patches/unlcms-366-dont-release-savepoint-on-install.patch",
                 "3060504 - Media Library widget does not render svg images": "patches/media-library-widget-does-not-render-svg-images-3060504-1.patch",
-                "2755791 - Ajax error ajax.$form.ajaxSubmit() is not a function": "patches/drupal-2755791-36.patch"
+                "2755791 - Ajax error ajax.$form.ajaxSubmit() is not a function": "patches/drupal-2755791-36.patch",
+                "3315678 - strnatcasecmp-Passing-null-to-parameter-2of-type-string-is-deprecated-3315678-25": "patches/strnatcasecmp-Passing-null-to-parameter-2of-type-string-is-deprecated-3315678-25.patch"
             },
             "drupal/block_content_permissions": {
                 "2920739 - Allow accessing the 'Custom block library' page without 'Administer blocks' permission": "patches/2920739-55.access_listing_page.patch"

--- a/config/sync/core.entity_form_display.block_content.contact_info.default.yml
+++ b/config/sync/core.entity_form_display.block_content.contact_info.default.yml
@@ -16,7 +16,7 @@ mode: default
 content:
   b_cinfo_contact_point:
     type: paragraphs
-    weight: 0
+    weight: 1
     region: content
     settings:
       title: Paragraph
@@ -32,5 +32,12 @@ content:
         collapse_edit_all: collapse_edit_all
         duplicate: duplicate
     third_party_settings: {  }
-hidden:
-  info: true
+  info:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden: {  }

--- a/config/sync/views.view.group_related_links_block.yml
+++ b/config/sync/views.view.group_related_links_block.yml
@@ -91,7 +91,7 @@ display:
         type: some
         options:
           offset: 0
-          items_per_page: 5
+          items_per_page: 1
       exposed_form:
         type: basic
         options:
@@ -180,6 +180,11 @@ display:
         type: default
       row:
         type: fields
+        options:
+          default_field_elements: true
+          inline: {  }
+          separator: ''
+          hide_empty: false
       query:
         type: views_query
         options:
@@ -219,6 +224,7 @@ display:
           entity_field: gid
           plugin_id: standard
           required: false
+      group_by: false
       header: {  }
       footer: {  }
       display_extenders: {  }

--- a/patches/strnatcasecmp-Passing-null-to-parameter-2of-type-string-is-deprecated-3315678-25.patch
+++ b/patches/strnatcasecmp-Passing-null-to-parameter-2of-type-string-is-deprecated-3315678-25.patch
@@ -1,0 +1,29 @@
+diff --git a/core/lib/Drupal/Core/Layout/LayoutPluginManager.php b/core/lib/Drupal/Core/Layout/LayoutPluginManager.php
+index 2265194bf3..b069572bc9 100644
+--- a/core/lib/Drupal/Core/Layout/LayoutPluginManager.php
++++ b/core/lib/Drupal/Core/Layout/LayoutPluginManager.php
+@@ -201,9 +201,9 @@ public function getSortedDefinitions(array $definitions = NULL, $label_key = 'la
+     $definitions = $definitions ?? $this->getDefinitions();
+     uasort($definitions, function (LayoutDefinition $a, LayoutDefinition $b) {
+       if ($a->getCategory() != $b->getCategory()) {
+-        return strnatcasecmp($a->getCategory(), $b->getCategory());
++        return strnatcasecmp($a->getCategory() ?? '', $b->getCategory() ?? '');
+       }
+-      return strnatcasecmp($a->getLabel(), $b->getLabel());
++      return strnatcasecmp($a->getLabel() ?? '', $b->getLabel() ?? '');
+     });
+     return $definitions;
+   }
+diff --git a/core/lib/Drupal/Core/Plugin/CategorizingPluginManagerTrait.php b/core/lib/Drupal/Core/Plugin/CategorizingPluginManagerTrait.php
+index 1ce1446802..3e3f1eeb1c 100644
+--- a/core/lib/Drupal/Core/Plugin/CategorizingPluginManagerTrait.php
++++ b/core/lib/Drupal/Core/Plugin/CategorizingPluginManagerTrait.php
+@@ -89,6 +89,8 @@ public function getSortedDefinitions(array $definitions = NULL, $label_key = 'la
+     // Sort the plugins first by category, then by label.
+     $definitions = $definitions ?? $this->getDefinitions();
+     uasort($definitions, function ($a, $b) use ($label_key) {
++      $a['category'] = $a['category'] ?? '';
++      $b['category'] = $b['category'] ?? '';
+       if ((string) $a['category'] != (string) $b['category']) {
+         return strnatcasecmp($a['category'], $b['category']);
+       }

--- a/web/modules/custom/features/herbie_builder_page/config/install/core.entity_form_display.block_content.contact_info.default.yml
+++ b/web/modules/custom/features/herbie_builder_page/config/install/core.entity_form_display.block_content.contact_info.default.yml
@@ -13,7 +13,7 @@ mode: default
 content:
   b_cinfo_contact_point:
     type: paragraphs
-    weight: 0
+    weight: 1
     region: content
     settings:
       title: Paragraph
@@ -29,5 +29,12 @@ content:
         collapse_edit_all: collapse_edit_all
         duplicate: duplicate
     third_party_settings: {  }
-hidden:
-  info: true
+  info:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden: {  }

--- a/web/modules/custom/features/herbie_builder_page/herbie_builder_page.info.yml
+++ b/web/modules/custom/features/herbie_builder_page/herbie_builder_page.info.yml
@@ -41,6 +41,7 @@ dependencies:
   - 'drupal:toolbar'
   - 'drupal:user'
   - 'drupal:views_ui'
+  - 'drupal:workflows'
   - 'entity_reference_revisions:entity_reference_revisions'
   - 'entity_usage:entity_usage'
   - 'entitygroupfield:entitygroupfield'
@@ -75,5 +76,5 @@ dependencies:
   - 'unl_news:unl_news'
   - 'webform:webform'
   - 'webform:webform_submission_log'
-version: 1.8.4
+version: 1.8.5
 package: Herbie

--- a/web/modules/custom/features/herbie_group/config/install/views.view.group_related_links_block.yml
+++ b/web/modules/custom/features/herbie_group/config/install/views.view.group_related_links_block.yml
@@ -90,7 +90,7 @@ display:
         type: some
         options:
           offset: 0
-          items_per_page: 5
+          items_per_page: 1
       exposed_form:
         type: basic
         options:
@@ -179,6 +179,11 @@ display:
         type: default
       row:
         type: fields
+        options:
+          default_field_elements: true
+          inline: {  }
+          separator: ''
+          hide_empty: false
       query:
         type: views_query
         options:
@@ -218,6 +223,7 @@ display:
           entity_field: gid
           plugin_id: standard
           required: false
+      group_by: false
       header: {  }
       footer: {  }
       display_extenders: {  }

--- a/web/modules/custom/features/herbie_group/herbie_group.info.yml
+++ b/web/modules/custom/features/herbie_group/herbie_group.info.yml
@@ -22,5 +22,5 @@ dependencies:
   - 'herbie_person:herbie_person'
   - 'herbie_roles:herbie_roles'
   - 'inline_entity_form:inline_entity_form'
-version: 1.0.3
+version: 1.0.4
 package: Herbie

--- a/web/modules/custom/unl_group/unl_group.module
+++ b/web/modules/custom/unl_group/unl_group.module
@@ -30,3 +30,49 @@ function unl_group_field_widget_single_element_form_alter(&$field_widget_complet
     $field_widget_complete_form['subform']['#access'] = FALSE;
   }
 }
+
+/**
+ * Implements hook_update_1001().
+ * Some group pages have created "Contact Info" blocks without descriptions because the description
+ * field was disabled during their creation.
+ * This update ensures a description is added to prevent a
+ * PHP deprecated function warning: Deprecated function: strnatcasecmp().
+ */
+function unl_group_update_1001() {
+  if (\Drupal::service('module_handler')->moduleExists('group')) {
+    $group_storage = \Drupal::entityTypeManager()->getStorage('group');
+
+    if ($group_storage) {
+      $group_ids = $group_storage->getQuery()
+        ->condition('type', 'group_subsite')
+        ->accessCheck(TRUE)
+        ->execute();
+
+      if ($group_ids) {
+        // Load the block storage service.
+        $custom_blocks = \Drupal::entityTypeManager()->getStorage('block_content');
+        // Load all custom block entities.
+        $blocks = $custom_blocks->loadMultiple();
+
+        // Loop through all blocks.
+        foreach ($blocks as $block) {
+          $block_id = $block->id();
+          $block_type = $block->bundle();
+
+          if (!empty($block_id) && $block_type == 'contact_info') {
+            // If contact info block's description is empty set the description
+            if (!$block->get('info')->getValue()) {
+              $contact_info_block_description = 'Contact us';
+              $block->set('info', $contact_info_block_description);
+              $block->save();
+              \Drupal::logger('unl_group')->notice('Updated description for block ID: @id', ['@id' => $block_id]);
+            }
+          }
+        }
+      }
+
+      // Return a status message.
+      return t('Contact Info block descriptions have been updated.');
+    }
+  }
+}

--- a/web/modules/custom/unl_media/unl_media.module
+++ b/web/modules/custom/unl_media/unl_media.module
@@ -14,44 +14,51 @@ use Drupal\Core\Cache\Cache;
 function unl_media_entity_presave(\Drupal\Core\Entity\EntityInterface $entity) {
 
   if ($entity->getEntityTypeId() === 'node' && $entity->bundle() == 'builder_page') {
-  // Check if node is being updated/edited
-  if (!$entity->isNew()) {
+    // Check if node is being updated/edited
+    if (!$entity->isNew()) {
 
-    // Get original state of the node entity prior to the update
-    $original_entity = \Drupal::entityTypeManager()
-      ->getStorage('node')
-      ->loadUnchanged($entity->id());
+      // Get original state of the node entity prior to the update
+      $original_entity = \Drupal::entityTypeManager()
+        ->getStorage('node')
+        ->loadUnchanged($entity->id());
 
-    $updated_hero_block = $entity->get('s_n_hero');
-    $original_hero_block = $original_entity->get('s_n_hero');
+      $updated_hero_block = $entity->get('s_n_hero');
+      $original_hero_block = $original_entity->get('s_n_hero');
 
-    if ($updated_hero_block && $original_hero_block) {
+      if ($updated_hero_block && $original_hero_block) {
+        if ($updated_hero_block->referencedEntities()) {
+          $updated_hero_block_values = $updated_hero_block->referencedEntities()[0];
+        }
+        if ($original_hero_block->referencedEntities()) {
+          $original_hero_block_values = $original_hero_block->referencedEntities()[0];
+        }
 
-      $updated_hero_block_values = $updated_hero_block->referencedEntities()[0];
-      $original_hero_block_values = $original_hero_block->referencedEntities()[0];
+        if (isset($updated_hero_block_values)) {
+          if ($updated_object_position_field_value = $updated_hero_block_values->get('b_hero_img_obj_pos')->getValue()) {
+            $updated_object_position_field_value = $updated_hero_block_values->get('b_hero_img_obj_pos')->getValue()[0]['value'];
+          }
+          $hero_block_hero_iamge = $updated_hero_block_values->get('b_hero_image');
+        }
 
-      if ($updated_hero_block_values) {
-        $updated_object_position_field_value = $updated_hero_block_values->get('b_hero_img_obj_pos')->getValue()[0]['value'];
-        $hero_block_hero_iamge = $updated_hero_block_values->get('b_hero_image');
-      }
+        if (isset($original_hero_block_values)) {
+          if ($original_object_position_field_value = $original_hero_block_values->get('b_hero_img_obj_pos')->getValue()) {
+            $original_object_position_field_value = $original_hero_block_values->get('b_hero_img_obj_pos')->getValue()[0]['value'];
+          }
+        }
 
-      if ($original_hero_block_values) {
-        $original_object_position_field_value = $original_hero_block_values->get('b_hero_img_obj_pos')->getValue()[0]['value'];
-      }
-
-      // Check if object position field value has changed
-      if ($updated_object_position_field_value !== $original_object_position_field_value) {
-        if ($hero_block_hero_iamge) {
-          $hero_image_field = $updated_hero_block_values->get('b_hero_image');
-          $hero_media_entity = $hero_image_field->referencedEntities()[0];
-          $cacheTags = $hero_media_entity->getCacheTagsToInvalidate()[0];
-          // Clear the cache entry of the media item associated only with the hero block.
-          \Drupal::service('cache_tags.invalidator')->invalidateTags([$cacheTags]);
+        // Check if object position field value has changed
+        if (isset($updated_object_position_field_value) && isset($original_object_position_field_value) && ($updated_object_position_field_value !== $original_object_position_field_value)) {
+          if ($hero_block_hero_iamge) {
+            $hero_image_field = $updated_hero_block_values->get('b_hero_image');
+            $hero_media_entity = $hero_image_field->referencedEntities()[0];
+            $cacheTags = $hero_media_entity->getCacheTagsToInvalidate()[0];
+            // Clear the cache entry of the media item associated only with the hero block.
+            \Drupal::service('cache_tags.invalidator')->invalidateTags([$cacheTags]);
+          }
         }
       }
     }
   }
- }
 }
 
 /**
@@ -149,7 +156,7 @@ function unl_media_preprocess_filter_caption(&$variables) {
   @$dom->loadHTML($element_string);
   // Only proceed if element is <drupal-media>.
   $element = $dom->getElementsByTagName("drupal-media");
-  if (method_exists($element,'count') && $element->count() != 0) {
+  if (method_exists($element, 'count') && $element->count() != 0) {
     $element = $element->item(0);
     $data_view_mode = $element->getAttribute('data-view-mode');
 

--- a/web/modules/custom/unl_webform/unl_webform.module
+++ b/web/modules/custom/unl_webform/unl_webform.module
@@ -61,30 +61,32 @@ function unl_webform_form_alter(&$form, FormStateInterface &$form_state, $form_i
   }
 
   $fieldset_elements = [
-      'checkboxes',
-      'details',
-      'fieldset',
-      'radios',
-      'telephone_advanced',
-      'webform_address',
-      'webform_buttons',
-      'webform_buttons_other',
-      'webform_checkboxes_other',
-      'webform_name',
-      'webform_radios_other',
-      'webform_select_other',
-      'webform_telephone',
-    ];
-    // Add required text on fieldset webform elements
-    if($form['#entity_type'] == 'webform_submission' || $form['#theme'][0] == 'webform_submission_form') {
-      foreach($form['elements'] as $key => $element) {
-        if(in_array($element['#type'], $fieldset_elements)) {
-          if($element['#required'] ==  true) {
+    'checkboxes',
+    'details',
+    'fieldset',
+    'radios',
+    'telephone_advanced',
+    'webform_address',
+    'webform_buttons',
+    'webform_buttons_other',
+    'webform_checkboxes_other',
+    'webform_name',
+    'webform_radios_other',
+    'webform_select_other',
+    'webform_telephone',
+  ];
+  // Add required text on fieldset webform elements
+  if (isset($form['#entity_type'])) {
+    if ($form['#entity_type'] == 'webform_submission' || $form['#theme'][0] == 'webform_submission_form') {
+      foreach ($form['elements'] as $key => $element) {
+        if (in_array($element['#type'], $fieldset_elements)) {
+          if ($element['#required'] ==  true) {
             $form['elements'][$key]['#title'] = $element['#title'] . ' <small class="dcf-required dcf-regular">Required</small>';
+          }
         }
-       }
       }
     }
+  }
 }
 
 /**
@@ -474,7 +476,7 @@ function unl_webform_entity_access(\Drupal\Core\Entity\EntityInterface $entity, 
       }
     }
   }
-  
+
   // Grant access (delegate access decisions to the webform module or other modules) if none of the conditions restrict it.
   return AccessResult::neutral();
 }

--- a/web/themes/custom/unl_five_herbie/unl_five_herbie.theme
+++ b/web/themes/custom/unl_five_herbie/unl_five_herbie.theme
@@ -114,15 +114,17 @@ function unl_five_herbie_preprocess_block(&$variables) {
      if($variables['elements']['#id'] == 'unl_five_herbie_contactinfo') {
       $variables['hide_block'] = TRUE;
      }
-   }
+
   }
   // If it's a group page, hide main site's Related Links block.
-  if($variables['elements']['#id'] == "unl_five_herbie_relatedlinks") {
-   $group = _unl_five_get_current_group();
-    if ($group) {
-     $variables['hide_related_links_block'] = TRUE;
-    }
-   }
+  if(isset($variables['elements']['#id'])) {
+    if($variables['elements']['#id'] == "unl_five_herbie_relatedlinks") {
+      $group = _unl_five_get_current_group();
+       if ($group) {
+        $variables['hide_related_links_block'] = TRUE;
+       }
+      }
+  }
   // Make section Layout Builder Block Styles array available to each block in the layout.
   // Values can be accessed in a Twig template with data.block_lbs, see unl_five_herbie_preprocess_block().
   if (isset($variables['elements']['#layout_builder_style']) && !empty($variables['elements']['#layout_builder_style'])) {
@@ -136,8 +138,7 @@ function unl_five_herbie_preprocess_block(&$variables) {
     $variables['content']['#block_content']->__set('#block_lbs', $block_layout_builder_styles);
   }
 }
-
-
+}
 /**
  * Implements template_preprocess_node__TYPE().
  */


### PR DESCRIPTION
I looked into the cause of this warning message, and it seems to happen when a contact block is created without a description. The following pull request has these changes.

- [x] Apply patch that prevents passing null value to strnatcasecmp()
- [x] Enables block description for contact info block (component)
- [x] Added a unl_group_update_1001() that will run with updb to add a description to all contact info blocks on a site that does not have them. This permanently prevents the strnatcasecmp()warning message from happening.
- [x] Refactored code to remove other warning messages seen on sites
- [x] Fixed group related links from repeating
- [x] Changed the way we are identifying sites that have groups in order to invalidate block cache data

There is also a pull request for the unl_five repo updating code that will remove other warning messages https://github.com/unlcms/unl_five/pull/82 (This pull request also includes a different way of checking sites that have groups in order to invalidate the cache, removed queries)




-----------
It looks like some contact_info blocks are being created on some sites like ianr and nemap. And they are being created with no block description. Not sure how that is happening but that is what's causing this issue I believe. Looking into a permanent fix for this.

closes #868 