### PR TITLE
Undefined array key #type warning message 878

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -324,7 +324,8 @@
                 "Custom (gh#366) - ProxySQL bug sidestep: don't release savepoints during site install": "patches/unlcms-366-dont-release-savepoint-on-install.patch",
                 "3060504 - Media Library widget does not render svg images": "patches/media-library-widget-does-not-render-svg-images-3060504-1.patch",
                 "2755791 - Ajax error ajax.$form.ajaxSubmit() is not a function": "patches/drupal-2755791-36.patch",
-                "3315678 - strnatcasecmp-Passing-null-to-parameter-2of-type-string-is-deprecated-3315678-25": "patches/strnatcasecmp-Passing-null-to-parameter-2of-type-string-is-deprecated-3315678-25.patch"
+                "3315678 - strnatcasecmp-Passing-null-to-parameter-2of-type-string-is-deprecated-3315678-25": "patches/strnatcasecmp-Passing-null-to-parameter-2of-type-string-is-deprecated-3315678-25.patch",
+                "2700667-133b - Undefined array key type in Drupal\\Core\\Form\\FormHelper::processStates()": "patches/2700667-133b.patch"
             },
             "drupal/block_content_permissions": {
                 "2920739 - Allow accessing the 'Custom block library' page without 'Administer blocks' permission": "patches/2920739-55.access_listing_page.patch"

--- a/patches/2700667-133b.patch
+++ b/patches/2700667-133b.patch
@@ -1,0 +1,65 @@
+diff --git a/core/lib/Drupal/Core/Form/FormHelper.php b/core/lib/Drupal/Core/Form/FormHelper.php
+index 68066ba..dfa76e2 100644
+--- a/core/lib/Drupal/Core/Form/FormHelper.php
++++ b/core/lib/Drupal/Core/Form/FormHelper.php
+@@ -196,6 +196,11 @@ protected static function processStatesArray(array &$conditions, $search, $repla
+    *   ],
+    * @endcode
+    *
++   * Drupal form elements are not required to support states. For states to
++   * work, the element has to print #attributes. Item elements work using
++   * #wrapper_attributes instead. States are not supported by render arrays
++   * where #type is markup.
++   *
+    * @param array $elements
+    *   A render array element having a #states property as described above.
+    *
+@@ -208,7 +213,10 @@ public static function processStates(array &$elements) {
+     // still want to be able to show/hide them. Since there's no actual HTML
+     // input element available, setting #attributes does not make sense, but a
+     // wrapper is available, so setting #wrapper_attributes makes it work.
+-    $key = ($elements['#type'] == 'item') ? '#wrapper_attributes' : '#attributes';
++    // @todo We should not check for #type being set here. That's masking deeper
++    // problems in other places that would trigger a warning here. See
++    // https://www.drupal.org/node/todo
++    $key = isset($elements['#type']) && $elements['#type'] === 'item' ? '#wrapper_attributes' : '#attributes';
+     $elements[$key]['data-drupal-states'] = Json::encode($elements['#states']);
+   }
+
+diff --git a/core/tests/Drupal/KernelTests/Core/Common/DrupalProcessStatesTest.php b/core/tests/Drupal/KernelTests/Core/Common/DrupalProcessStatesTest.php
+new file mode 100644
+index 0000000..71c2bbd
+--- /dev/null
++++ b/core/tests/Drupal/KernelTests/Core/Common/DrupalProcessStatesTest.php
+@@ -0,0 +1,31 @@
++<?php
++
++namespace Drupal\KernelTests\Core\Common;
++
++use Drupal\Core\Form\FormHelper;
++use Drupal\KernelTests\KernelTestBase;
++
++/**
++ * @covers \Drupal\Core\Form\FormHelper::processStates
++ * @group Common
++ */
++class DrupalProcessStatesTest extends KernelTestBase {
++
++  /**
++   * Tests that FormHelper::processStates() doesn't cause any notices.
++   */
++  public function testProcessStates() {
++    // Create a form element without specifying a '#type'.
++    $form_element = [
++      '#markup' => 'Custom markup',
++      '#states' => [
++        'visible' => [
++          ':select[name="method"]' => ['value' => 'email'],
++        ],
++      ],
++    ];
++    FormHelper::processStates($form_element);
++    $this->assertArrayHasKey('#attributes', $form_element);
++  }
++
++}

--- a/web/modules/custom/unl_blocks/unl_blocks.module
+++ b/web/modules/custom/unl_blocks/unl_blocks.module
@@ -59,7 +59,7 @@ function unl_blocks_block_type_form_alter(array &$form, FormStateInterface &$for
         ]
       ],
     ];
-    $form['b_card_cta_style']['widget']['#states'] = [
+    $form['b_card_cta_style']['#states'] = [
       'required' => [
         [
           'input[name="b_card_cta[0][uri]"' => ['filled' => TRUE],

--- a/web/modules/custom/unl_layout_builder_custom/unl_layout_builder_custom.module
+++ b/web/modules/custom/unl_layout_builder_custom/unl_layout_builder_custom.module
@@ -120,36 +120,36 @@ function _add_tandem_block_form_elements(array $element, FormStateInterface $for
     ],
   ];
 
-  $element['b_tandem_shadow_position']['widget']['#states'] = array('invisible' => array(
+  $element['b_tandem_shadow_position']['#states'] = array('invisible' => array(
     array ('select[id="edit-settings-block-form-b-tandem-style"]' => array('value' => '2'),),
     array ('select[id="edit-settings-block-form-b-tandem-style"]' => array('value' => '1'),),
     array ('select[id="edit-settings-block-form-b-tandem-add-image-shadow"]' => array('value' => 'no'),),),);
 
-  $element['b_tandem_shadow_style']['widget']['#states'] = array('invisible' => array(
+  $element['b_tandem_shadow_style']['#states'] = array('invisible' => array(
     array ('select[id="edit-settings-block-form-b-tandem-style"]' => array('value' => '2'),),
     array ('select[id="edit-settings-block-form-b-tandem-style"]' => array('value' => '1'),),
     array ('select[id="edit-settings-block-form-b-tandem-add-image-shadow"]' => array('value' => 'no'),),),);
 
-  $element['b_tandem_image_position']['widget']['#states'] =  array('visible' => array(
+  $element['b_tandem_image_position']['#states'] =  array('visible' => array(
     'select[id="edit-settings-block-form-b-tandem-style"]' => array('value' => '3')
   ));
 
-  $element['b_tandem_stack']['widget']['#states'] =  array('visible' => array(
+  $element['b_tandem_stack']['#states'] =  array('visible' => array(
     'select[id="edit-settings-block-form-b-tandem-style"]' => array('value' => '2')
   ));
 
-  $element['b_tandem_fade']['widget']['#states'] =  array('visible' => array(
+  $element['b_tandem_fade']['#states'] =  array('visible' => array(
     'select[id="edit-settings-block-form-b-tandem-style"]' => array('value' => '1')
   ));
 
   if (isset($element['b_tandem_buttons'])) {
-  $element['b_tandem_buttons']['widget']['#states'] =  array('visible' => array(
+  $element['b_tandem_buttons']['#states'] =  array('visible' => array(
       'select[id="edit-settings-block-form-b-tandem-add-buttons-or-links"]' => array('value' => 'buttons')
     ));
   }
 
   if (isset($element['b_tandem_links'])) {
-    $element['b_tandem_links']['widget']['#states'] =  array('visible' => array(
+    $element['b_tandem_links']['#states'] =  array('visible' => array(
       'select[id="edit-settings-block-form-b-tandem-add-buttons-or-links"]' => array('value' => 'links')
     ));
   }
@@ -162,12 +162,12 @@ function _add_tandem_block_form_elements(array $element, FormStateInterface $for
  */
 function _edit_tandem_block_form_elements(array $element, FormStateInterface $form_state) {
 
-  $element['b_tandem_shadow_position']['widget']['#states'] = array('invisible' => array(
+  $element['b_tandem_shadow_position']['#states'] = array('invisible' => array(
     array ('select[id="edit-settings-block-form-b-tandem-style"]' => array('value' => '2'),),
     array ('select[id="edit-settings-block-form-b-tandem-style"]' => array('value' => '1'),),
     array ('select[id="edit-settings-block-form-b-tandem-add-image-shadow"]' => array('value' => 'no'),),),);
 
-  $element['b_tandem_shadow_style']['widget']['#states'] = array('invisible' => array(
+  $element['b_tandem_shadow_style']['#states'] = array('invisible' => array(
     array ('select[id="edit-settings-block-form-b-tandem-style"]' => array('value' => '2'),),
     array ('select[id="edit-settings-block-form-b-tandem-style"]' => array('value' => '1'),),
     array ('select[id="edit-settings-block-form-b-tandem-add-image-shadow"]' => array('value' => 'no'),),),);
@@ -180,26 +180,26 @@ function _edit_tandem_block_form_elements(array $element, FormStateInterface $fo
       ],
     ];
 
-  $element['b_tandem_image_position']['widget']['#states'] =  array('visible' => array(
+  $element['b_tandem_image_position']['#states'] =  array('visible' => array(
     'select[id="edit-settings-block-form-b-tandem-style"]' => array('value' => '3')
     ));
 
-    $element['b_tandem_stack']['widget']['#states'] =  array('visible' => array(
+    $element['b_tandem_stack']['#states'] =  array('visible' => array(
       'select[id="edit-settings-block-form-b-tandem-style"]' => array('value' => '2')
     ));
 
-    $element['b_tandem_fade']['widget']['#states'] =  array('visible' => array(
+    $element['b_tandem_fade']['#states'] =  array('visible' => array(
       'select[id="edit-settings-block-form-b-tandem-style"]' => array('value' => '1')
     ));
 
   if (isset($element['b_tandem_buttons'])) {
-    $element['b_tandem_buttons']['widget']['#states'] =  array('visible' => array(
+    $element['b_tandem_buttons']['#states'] =  array('visible' => array(
       'select[id="edit-settings-block-form-b-tandem-add-buttons-or-links"]' => array('value' => 'buttons')
     ));
   }
 
   if (isset($element['b_tandem_links'])) {
-    $element['b_tandem_links']['widget']['#states'] =  array('visible' => array(
+    $element['b_tandem_links']['#states'] =  array('visible' => array(
       'select[id="edit-settings-block-form-b-tandem-add-buttons-or-links"]' => array('value' => 'links')
     ));
   }
@@ -211,10 +211,10 @@ function _edit_tandem_block_form_elements(array $element, FormStateInterface $fo
  * Callback function.
  */
 function _add_edit_simple_media_block_form_elements(array $element, FormStateInterface $form_state) {
-  $element['b_simple_media_shadow_position']['widget']['#states'] = array('visible' => array(
+  $element['b_simple_media_shadow_position']['#states'] = array('visible' => array(
     array ('select[id="edit-settings-block-form-b-simple-media-frame-or-shadow"]' => array('value' => 'shadow'))));
 
-  $element['b_simple_media_shadow_style']['widget']['#states'] = array('visible' => array(
+  $element['b_simple_media_shadow_style']['#states'] = array('visible' => array(
     array ('select[id="edit-settings-block-form-b-simple-media-frame-or-shadow"]' => array('value' => 'shadow'))));
 
   return $element;
@@ -225,7 +225,7 @@ function _add_edit_simple_media_block_form_elements(array $element, FormStateInt
  * Callback function.
  */
 function _edit_card_block_form_elements(array $element, FormStateInterface $form_state) {
-  $element['b_card_cta']['widget']['#states'] =  array('visible' => array(
+  $element['b_card_cta']['#states'] =  array('visible' => array(
     'input[id="edit-settings-block-form-b-card-headline-link-0-uri"]' => array('value' => '')
   ));
   return $element;


### PR DESCRIPTION
This warning message occurs whenever we edit and save components like cards or tandem since we use the #states property to hide and show form fields. The issue's description provides more information. 

Issue's description: 

> This warning message happens whenever we edit and save components like cards or tandem since we use #states property to hide and show form fields.
> 
> Drupal 10.3.x core update needed. Or we would need to apply the patch found on https://www.drupal.org/files/issues/2021-05-12/2700667-133b.patch. Comment 133.
> 
> Bob mentioned this warning message happening on sites like https://cms.unl.edu/ianr/extension

Closes #878 