### PR TITLE
Added define.amd wrap around to other plugin inits

### DIFF
--- a/web/themes/custom/unl_five_herbie/js/theme/card.js
+++ b/web/themes/custom/unl_five_herbie/js/theme/card.js
@@ -1,3 +1,24 @@
 window.addEventListener('inlineJSReady', function() {
-  WDN.initializePlugin('card-as-link');
+
+  if (define.amd === undefined) {
+    define.amd = define.origAmd;
+    delete define.origAmd;
+  }
+  window.WDNPluginsExecuting++;
+  
+  WDN.initializePlugin(
+    'card-as-link',
+    {},
+    cardAsLinkCallback,
+    'after'
+  );
+ 
+  function cardAsLinkCallback() {
+    window.WDNPluginsExecuting--;
+    if (define.origAmd === undefined && window.WDNPluginsExecuting === 0) {
+      define.origAmd = define.amd;
+      delete define.amd;
+    }
+  }
+
 }, false);

--- a/web/themes/custom/unl_five_herbie/js/theme/news_article.js
+++ b/web/themes/custom/unl_five_herbie/js/theme/news_article.js
@@ -1,3 +1,24 @@
 window.addEventListener('inlineJSReady', function() {
-  WDN.initializePlugin('card-as-link');
-});
+
+  if (define.amd === undefined) {
+    define.amd = define.origAmd;
+    delete define.origAmd;
+  }
+  window.WDNPluginsExecuting++;
+  
+  WDN.initializePlugin(
+    'card-as-link',
+    {},
+    cardAsLinkCallback,
+    'after'
+  );
+ 
+  function cardAsLinkCallback() {
+    window.WDNPluginsExecuting--;
+    if (define.origAmd === undefined && window.WDNPluginsExecuting === 0) {
+      define.origAmd = define.amd;
+      delete define.amd;
+    }
+  }
+
+}, false);

--- a/web/themes/custom/unl_five_herbie/js/theme/slideshow.js
+++ b/web/themes/custom/unl_five_herbie/js/theme/slideshow.js
@@ -1,3 +1,24 @@
 window.addEventListener('inlineJSReady', function() {
-   WDN.initializePlugin('slideshows');
-  }, false);
+
+   if (define.amd === undefined) {
+      define.amd = define.origAmd;
+      delete define.origAmd;
+   }
+   window.WDNPluginsExecuting++;
+
+   WDN.initializePlugin(
+      'slideshows',
+      {},
+      slideshowCallback,
+      'after'
+   );
+
+   function slideshowCallback() {
+      window.WDNPluginsExecuting--;
+      if (define.origAmd === undefined && window.WDNPluginsExecuting === 0) {
+         define.origAmd = define.amd;
+         delete define.amd;
+      }
+   }
+
+}, false);

--- a/web/themes/custom/unl_five_herbie/js/theme/tabs.js
+++ b/web/themes/custom/unl_five_herbie/js/theme/tabs.js
@@ -1,3 +1,27 @@
 window.addEventListener('inlineJSReady', function() {
     WDN.initializePlugin('tabs');
 }, false);
+window.addEventListener('inlineJSReady', function() {
+
+    if (define.amd === undefined) {
+       define.amd = define.origAmd;
+       delete define.origAmd;
+    }
+    window.WDNPluginsExecuting++;
+ 
+    WDN.initializePlugin(
+       'tabs',
+       {},
+       tabsCallback,
+       'after'
+    );
+ 
+    function tabsCallback() {
+       window.WDNPluginsExecuting--;
+       if (define.origAmd === undefined && window.WDNPluginsExecuting === 0) {
+          define.origAmd = define.amd;
+          delete define.amd;
+       }
+    }
+ 
+ }, false);


### PR DESCRIPTION
The define.amd wrap around seems to fix most plugin initializations but some places were missing that code. So I went through and implemented it