### PR TITLE
Changed the current url pattern code to include a resolution for this issue. 

### DIFF
--- a/web/modules/custom/unl_pathauto/unl_pathauto.module
+++ b/web/modules/custom/unl_pathauto/unl_pathauto.module
@@ -37,7 +37,7 @@ function unl_pathauto_pathauto_pattern_alter(PathautoPatternInterface $pattern, 
     }
 
     // Check if the current route is on a regular edit page.
-    if ($current_route_name == "entity.node.edit_form") {
+    if ($current_route_name == "entity.node.edit_form" || $current_route_name == "entity.group_relationship.create_form" || $current_route_name == "node.add" ||  $current_route_name == "entity.group_relationship.add_form") {
       // Get menu object from the context
       $menu = $context['data']['node']->__get('menu');
       // If the menu is not set, or if the menu is not enabled on an edit-only page,


### PR DESCRIPTION
Fixes #918.

The main issue was that menu = $context['data']['node']->__get('menu'); returned null when a page was saved from the layout builder side, so this approach was not used. Instead, I used the menu link manager to check if that page's menu object is enabled when editing and saving from the layout side. Used context for when just editing the page through the regular edit interface.