### PR TITLE
Made the Accordion block title field optional. Added a checkbox to expand or collapse each individual accordion item. Fixes #699. Fixes #756. Fixes #807.

### DIFF
--- a/config/sync/core.entity_form_display.paragraph.accordion_item.default.yml
+++ b/config/sync/core.entity_form_display.paragraph.accordion_item.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.paragraph.accordion_item.p_b_accrd_item_body
+    - field.field.paragraph.accordion_item.p_b_accrd_item_expand_accordion
     - field.field.paragraph.accordion_item.p_b_accrd_item_title
     - paragraphs.paragraphs_type.accordion_item
   module:
@@ -23,6 +24,13 @@ content:
       rows: 5
       placeholder: ''
     third_party_settings: {  }
+  p_b_accrd_item_expand_accordion:
+    type: boolean_checkbox
+    weight: 2
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
   p_b_accrd_item_title:
     type: string_textfield
     weight: 0
@@ -33,7 +41,7 @@ content:
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 2
+    weight: 3
     region: content
     settings:
       display_label: true

--- a/config/sync/core.entity_view_display.paragraph.accordion_item.default.yml
+++ b/config/sync/core.entity_view_display.paragraph.accordion_item.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.paragraph.accordion_item.p_b_accrd_item_body
+    - field.field.paragraph.accordion_item.p_b_accrd_item_expand_accordion
     - field.field.paragraph.accordion_item.p_b_accrd_item_title
     - paragraphs.paragraphs_type.accordion_item
   module:
@@ -21,6 +22,16 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: 1
+    region: content
+  p_b_accrd_item_expand_accordion:
+    type: boolean
+    label: hidden
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 2
     region: content
   p_b_accrd_item_title:
     type: string

--- a/config/sync/field.field.block_content.accordion.b_accordion_title.yml
+++ b/config/sync/field.field.block_content.accordion.b_accordion_title.yml
@@ -13,7 +13,7 @@ entity_type: block_content
 bundle: accordion
 label: Title
 description: ''
-required: true
+required: false
 translatable: false
 default_value: {  }
 default_value_callback: ''

--- a/config/sync/field.field.paragraph.accordion_item.p_b_accrd_item_expand_accordion.yml
+++ b/config/sync/field.field.paragraph.accordion_item.p_b_accrd_item_expand_accordion.yml
@@ -1,0 +1,23 @@
+uuid: 6f2599a6-67f1-4322-9a38-37343238242b
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.p_b_accrd_item_expand_accordion
+    - paragraphs.paragraphs_type.accordion_item
+id: paragraph.accordion_item.p_b_accrd_item_expand_accordion
+field_name: p_b_accrd_item_expand_accordion
+entity_type: paragraph
+bundle: accordion_item
+label: 'Expand Accordion'
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/sync/field.storage.paragraph.p_b_accrd_item_expand_accordion.yml
+++ b/config/sync/field.storage.paragraph.p_b_accrd_item_expand_accordion.yml
@@ -1,0 +1,18 @@
+uuid: b411c550-e361-464d-ac64-51ddd06c63f6
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.p_b_accrd_item_expand_accordion
+field_name: p_b_accrd_item_expand_accordion
+entity_type: paragraph
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/modules/custom/features/herbie_builder_page/config/install/core.entity_form_display.paragraph.accordion_item.default.yml
+++ b/web/modules/custom/features/herbie_builder_page/config/install/core.entity_form_display.paragraph.accordion_item.default.yml
@@ -3,6 +3,7 @@ status: true
 dependencies:
   config:
     - field.field.paragraph.accordion_item.p_b_accrd_item_body
+    - field.field.paragraph.accordion_item.p_b_accrd_item_expand_accordion
     - field.field.paragraph.accordion_item.p_b_accrd_item_title
     - paragraphs.paragraphs_type.accordion_item
   module:
@@ -20,6 +21,13 @@ content:
       rows: 5
       placeholder: ''
     third_party_settings: {  }
+  p_b_accrd_item_expand_accordion:
+    type: boolean_checkbox
+    weight: 2
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
   p_b_accrd_item_title:
     type: string_textfield
     weight: 0
@@ -30,7 +38,7 @@ content:
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 2
+    weight: 3
     region: content
     settings:
       display_label: true

--- a/web/modules/custom/features/herbie_builder_page/config/install/core.entity_view_display.paragraph.accordion_item.default.yml
+++ b/web/modules/custom/features/herbie_builder_page/config/install/core.entity_view_display.paragraph.accordion_item.default.yml
@@ -3,6 +3,7 @@ status: true
 dependencies:
   config:
     - field.field.paragraph.accordion_item.p_b_accrd_item_body
+    - field.field.paragraph.accordion_item.p_b_accrd_item_expand_accordion
     - field.field.paragraph.accordion_item.p_b_accrd_item_title
     - paragraphs.paragraphs_type.accordion_item
   module:
@@ -18,6 +19,16 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: 1
+    region: content
+  p_b_accrd_item_expand_accordion:
+    type: boolean
+    label: hidden
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 2
     region: content
   p_b_accrd_item_title:
     type: string

--- a/web/modules/custom/features/herbie_builder_page/config/install/field.field.block_content.accordion.b_accordion_title.yml
+++ b/web/modules/custom/features/herbie_builder_page/config/install/field.field.block_content.accordion.b_accordion_title.yml
@@ -10,7 +10,7 @@ entity_type: block_content
 bundle: accordion
 label: Title
 description: ''
-required: true
+required: false
 translatable: false
 default_value: {  }
 default_value_callback: ''

--- a/web/modules/custom/features/herbie_builder_page/config/install/field.field.paragraph.accordion_item.p_b_accrd_item_expand_accordion.yml
+++ b/web/modules/custom/features/herbie_builder_page/config/install/field.field.paragraph.accordion_item.p_b_accrd_item_expand_accordion.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.p_b_accrd_item_expand_accordion
+    - paragraphs.paragraphs_type.accordion_item
+id: paragraph.accordion_item.p_b_accrd_item_expand_accordion
+field_name: p_b_accrd_item_expand_accordion
+entity_type: paragraph
+bundle: accordion_item
+label: 'Expand Accordion'
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/web/modules/custom/features/herbie_builder_page/config/install/field.storage.paragraph.p_b_accrd_item_expand_accordion.yml
+++ b/web/modules/custom/features/herbie_builder_page/config/install/field.storage.paragraph.p_b_accrd_item_expand_accordion.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.p_b_accrd_item_expand_accordion
+field_name: p_b_accrd_item_expand_accordion
+entity_type: paragraph
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/modules/custom/features/herbie_builder_page/herbie_builder_page.info.yml
+++ b/web/modules/custom/features/herbie_builder_page/herbie_builder_page.info.yml
@@ -77,5 +77,5 @@ dependencies:
   - 'unl_news:unl_news'
   - 'webform:webform'
   - 'webform:webform_submission_log'
-version: 1.9.1
+version: 1.9.2
 package: Herbie

--- a/web/themes/custom/unl_five_herbie/templates/block/block--block-content-accordion.html.twig
+++ b/web/themes/custom/unl_five_herbie/templates/block/block--block-content-accordion.html.twig
@@ -28,7 +28,9 @@
 <div{{ attributes.addClass('dcf-d-flex').addClass('dcf-jc-center').addClass('dcf-pt-9').addClass('dcf-pb-9') }}>
   <div class="dcf-w-100% dcf-w-max-lg">
     {{ title_prefix }}
-      <h2>{{ content.b_accordion_title }}</h2>
+      {% if content.b_accordion_title.0 %}
+        <h2>{{ content.b_accordion_title }}</h2>
+      {% endif %}
     {{ title_suffix }}
     {% block content %}
       <div class="dcf-mt-6">

--- a/web/themes/custom/unl_five_herbie/templates/paragraph/paragraph--accordion-item--default.html.twig
+++ b/web/themes/custom/unl_five_herbie/templates/paragraph/paragraph--accordion-item--default.html.twig
@@ -47,9 +47,13 @@
   ]
 %}
 {% block paragraph %}
-  <details{{ attributes.addClass(classes) }}>
-    {% block content %}
-      {{ content }}
-    {% endblock %}
-  </details>
+  {% if paragraph.get('p_b_accrd_item_expand_accordion').value %}
+    <details{{ attributes.addClass(classes).setAttribute('open', true) }}>
+  {% else %}
+    <details{{ attributes.addClass(classes) }}>
+  {% endif %}
+      {% block content %}
+        {{ content }}
+      {% endblock %}
+    </details>
 {% endblock paragraph %}


### PR DESCRIPTION
By default, all accordion item content is collapsed unless checked using the Expand Accordion checkbox.