### PR TITLE
Added unlcms-spacer-class to all components. Added the margin-top: 2em value to selected components on the issue. Fixes #967.

### DIFF
--- a/web/themes/custom/unl_five_herbie/css/theme/block/accordion.css
+++ b/web/themes/custom/unl_five_herbie/css/theme/block/accordion.css
@@ -1,3 +1,4 @@
-.unlcms-component-spacer + .unlcms-component-spacer.unlcms-accordion-component {
+/* Adds spacing between multiple components within a section */
+.layout__region .unlcms-component-spacer + .unlcms-component-spacer.unlcms-accordion-component {
   margin-top: 2em;
 }

--- a/web/themes/custom/unl_five_herbie/css/theme/block/accordion.css
+++ b/web/themes/custom/unl_five_herbie/css/theme/block/accordion.css
@@ -1,0 +1,3 @@
+.unlcms-component-spacer + .unlcms-component-spacer.unlcms-accordion-component {
+  margin-top: 2em;
+}

--- a/web/themes/custom/unl_five_herbie/css/theme/block/card.css
+++ b/web/themes/custom/unl_five_herbie/css/theme/block/card.css
@@ -2,7 +2,8 @@
   margin-top: 2em;
 } */
 
-.unlcms-component-spacer + .unlcms-component-spacer.dcf-card {
+/* Spacing for multiple components in a section */
+.layout__region .unlcms-component-spacer + .unlcms-component-spacer.dcf-card {
   margin-top: 2em;
 }
 

--- a/web/themes/custom/unl_five_herbie/css/theme/block/card.css
+++ b/web/themes/custom/unl_five_herbie/css/theme/block/card.css
@@ -1,4 +1,8 @@
-.layout__region .dcf-card+.dcf-card {
+/* .layout__region .dcf-card+.dcf-card {
+  margin-top: 2em;
+} */
+
+.unlcms-component-spacer + .unlcms-component-spacer.dcf-card {
   margin-top: 2em;
 }
 

--- a/web/themes/custom/unl_five_herbie/css/theme/block/icon_links.css
+++ b/web/themes/custom/unl_five_herbie/css/theme/block/icon_links.css
@@ -1,3 +1,7 @@
+.unlcms-component-spacer + .unlcms-component-spacer.unlcms-iconlinks-component {
+  margin-top: 2em;
+}
+
 .unlcms-ul-icon-links  {
   display: flex;
   flex-wrap: wrap;

--- a/web/themes/custom/unl_five_herbie/css/theme/block/icon_links.css
+++ b/web/themes/custom/unl_five_herbie/css/theme/block/icon_links.css
@@ -1,4 +1,5 @@
-.unlcms-component-spacer + .unlcms-component-spacer.unlcms-iconlinks-component {
+/* Adds spacing between multiple components within a section */
+.layout__region .unlcms-component-spacer + .unlcms-component-spacer.unlcms-iconlinks-component {
   margin-top: 2em;
 }
 

--- a/web/themes/custom/unl_five_herbie/css/theme/block/logo_cloud.css
+++ b/web/themes/custom/unl_five_herbie/css/theme/block/logo_cloud.css
@@ -1,3 +1,7 @@
+.unlcms-component-spacer + .unlcms-component-spacer.unlcms-logocloud-component {
+  margin-top: 2em;
+}
+
 .unlcms-li-logo {
   flex: 0 0 10em;
 }

--- a/web/themes/custom/unl_five_herbie/css/theme/block/logo_cloud.css
+++ b/web/themes/custom/unl_five_herbie/css/theme/block/logo_cloud.css
@@ -1,4 +1,5 @@
-.unlcms-component-spacer + .unlcms-component-spacer.unlcms-logocloud-component {
+/* Adds spacing between multiple components within a section */
+.layout__region .unlcms-component-spacer + .unlcms-component-spacer.unlcms-logocloud-component {
   margin-top: 2em;
 }
 

--- a/web/themes/custom/unl_five_herbie/css/theme/block/social_media_links.css
+++ b/web/themes/custom/unl_five_herbie/css/theme/block/social_media_links.css
@@ -1,0 +1,3 @@
+.unlcms-component-spacer + .unlcms-component-spacer.unlcms-socialmedia-component {
+  margin-top: 2em;
+}

--- a/web/themes/custom/unl_five_herbie/css/theme/block/social_media_links.css
+++ b/web/themes/custom/unl_five_herbie/css/theme/block/social_media_links.css
@@ -1,3 +1,4 @@
-.unlcms-component-spacer + .unlcms-component-spacer.unlcms-socialmedia-component {
+/* Adds spacing between multiple components within a section */
+.layout__region .unlcms-component-spacer + .unlcms-component-spacer.unlcms-socialmedia-component {
   margin-top: 2em;
 }

--- a/web/themes/custom/unl_five_herbie/css/theme/block/timeline.css
+++ b/web/themes/custom/unl_five_herbie/css/theme/block/timeline.css
@@ -170,7 +170,7 @@
 .unlcms-timeline-horizontal .dcf-card {
   min-width: 23.68em;
 }
-
-.unlcms-component-spacer + .unlcms-component-spacer.unlcms-timeline-component {
+/* Adds spacing between multiple components within a section */
+.layout__region .unlcms-component-spacer + .unlcms-component-spacer.unlcms-timeline-component {
   margin-top: 2em;
 }

--- a/web/themes/custom/unl_five_herbie/css/theme/block/timeline.css
+++ b/web/themes/custom/unl_five_herbie/css/theme/block/timeline.css
@@ -170,3 +170,7 @@
 .unlcms-timeline-horizontal .dcf-card {
   min-width: 23.68em;
 }
+
+.unlcms-component-spacer + .unlcms-component-spacer.unlcms-timeline-component {
+  margin-top: 2em;
+}

--- a/web/themes/custom/unl_five_herbie/templates/block/block--block-content-accordion.html.twig
+++ b/web/themes/custom/unl_five_herbie/templates/block/block--block-content-accordion.html.twig
@@ -25,7 +25,8 @@
  * @see template_preprocess_block()
  */
 #}
-<div{{ attributes.addClass('dcf-d-flex').addClass('dcf-jc-center').addClass('dcf-pt-9').addClass('dcf-pb-9') }}>
+{{ attach_library('unl_five_herbie/accordion') }}
+<div{{ attributes.addClass('dcf-d-flex').addClass('dcf-jc-center').addClass('unlcms-component-spacer').addClass('unlcms-accordion-component') }}>
   <div class="dcf-w-100% dcf-w-max-lg">
     {{ title_prefix }}
       {% if content.b_accordion_title.0 %}

--- a/web/themes/custom/unl_five_herbie/templates/block/block--block-content-card.html.twig
+++ b/web/themes/custom/unl_five_herbie/templates/block/block--block-content-card.html.twig
@@ -9,7 +9,7 @@
 {% set image_wrapper_attributes = image_wrapper_attributes.addClass('dcf-1st dcf-ratio dcf-ratio-4x3') %}
 
 {% if content.b_card_headline_link[0]['#url']%}
-  <div{{ attributes.addclass(card_classes, 'dcf-card-as-link') }}>
+  <div{{ attributes.addclass(card_classes, 'dcf-card-as-link', 'unlcms-component-spacer') }}>
 {% else %}
   <div{{ attributes.addclass(card_classes) }}>
 {% endif %}

--- a/web/themes/custom/unl_five_herbie/templates/block/block--block-content-cta.html.twig
+++ b/web/themes/custom/unl_five_herbie/templates/block/block--block-content-cta.html.twig
@@ -1,9 +1,9 @@
 {{ attach_library('unl_five_herbie/cta') }}
 {% set attributes = attributes ?: create_attribute() %}
-{% set card_classes = ['unlcms-cta-block', 'dcf-col-100%', 'dcf-grid-thirds@md', 'dcf-col-gap-6', 'dcf-row-gap-3', 'dcf-p-6'] %}
+{% set call_to_action_classes = ['unlcms-component-spacer', 'unlcms-cta-block', 'dcf-col-100%', 'dcf-grid-thirds@md', 'dcf-col-gap-6', 'dcf-row-gap-3', 'dcf-p-6'] %}
 {{ attach_library('unl_five_herbie/cta') }}
 
-<div{{ attributes.addclass(card_classes) }}>
+<div{{ attributes.addclass(call_to_action_classes) }}>
   {{ title_prefix }}
   {{ title_suffix }}
   {% block cta_title %}

--- a/web/themes/custom/unl_five_herbie/templates/block/block--block-content-embed.html.twig
+++ b/web/themes/custom/unl_five_herbie/templates/block/block--block-content-embed.html.twig
@@ -28,7 +28,7 @@
  * @ingroup themeable
  */
 #}
-<div{{ attributes }}>
+<div{{ attributes.addClass('unlcms-component-spacer').addClass('unlcms-embed-component')  }}>
   {{ title_prefix }}
   {% if label %}
     <h2{{ title_attributes }}>{{ label }}</h2>

--- a/web/themes/custom/unl_five_herbie/templates/block/block--block-content-icon-links.html.twig
+++ b/web/themes/custom/unl_five_herbie/templates/block/block--block-content-icon-links.html.twig
@@ -1,5 +1,5 @@
 {{ attach_library('unl_five_herbie/icon_links') }}
-<div{{ attributes.addClass('dcf-pt-9').addClass('dcf-pb-9') }}>
+<div{{ attributes.addClass('unlcms-component-spacer').addClass('unlcms-iconlinks-component')}}>
   {{ title_prefix }}
   {{ title_suffix }}
   <ul class="dcf-list-bare dcf-col-gap-vw dcf-row-gap-7 dcf-mb-0 dcf-lh-3 dcf-bold unlcms-ul-icon-links">

--- a/web/themes/custom/unl_five_herbie/templates/block/block--block-content-logo-cloud.html.twig
+++ b/web/themes/custom/unl_five_herbie/templates/block/block--block-content-logo-cloud.html.twig
@@ -1,5 +1,5 @@
 {{ attach_library('unl_five_herbie/logo_cloud') }}
-<div{{ attributes.addClass('dcf-pt-9').addClass('dcf-pb-9') }}>
+<div{{ attributes.addClass('unlcms-component-spacer').addClass('unlcms-logocloud-component')}}>
   {{ title_prefix }}
   {{ title_suffix }}
   <ul class="dcf-list-bare dcf-d-flex dcf-flex-wrap dcf-jc-center dcf-col-gap-4 dcf-row-gap-4 dcf-mb-0">

--- a/web/themes/custom/unl_five_herbie/templates/block/block--block-content-photo-hero.html.twig
+++ b/web/themes/custom/unl_five_herbie/templates/block/block--block-content-photo-hero.html.twig
@@ -1,6 +1,6 @@
 {{ attach_library('unl_five_herbie/photo_hero') }}
 
-<div{{ attributes.addClass('dcf-d-grid unl-grid-cols dcf-row-gap-4 unlcms-display-banner') }}>
+<div{{ attributes.addClass('dcf-d-grid unl-grid-cols dcf-row-gap-4 unlcms-display-banner unlcms-component-spacer') }}>
 
   {{ title_prefix }}
   {{ title_suffix }}

--- a/web/themes/custom/unl_five_herbie/templates/block/block--block-content-proofpoint.html.twig
+++ b/web/themes/custom/unl_five_herbie/templates/block/block--block-content-proofpoint.html.twig
@@ -1,6 +1,6 @@
 {{ attach_library('unl_five_herbie/photo_hero') }}
 
-<div{{ attributes }}>
+<div{{ attributes.addClass('unlcms-component-spacer') }}>
 
   {{ title_prefix }}
   {{ title_suffix }}

--- a/web/themes/custom/unl_five_herbie/templates/block/block--block-content-simple-media.html.twig
+++ b/web/themes/custom/unl_five_herbie/templates/block/block--block-content-simple-media.html.twig
@@ -1,7 +1,7 @@
 {{ attach_library('unl_five_herbie/tandem') }}
 {{ attach_library('unl_five_herbie/simple_media') }}
 
-<div{{ attributes }}>
+<div{{ attributes.addClass('unlcms-component-spacer') }}>
   {{ title_prefix }}
   {% if label %}
     <h2{{ title_attributes }}>

--- a/web/themes/custom/unl_five_herbie/templates/block/block--block-content-slideshow.html.twig
+++ b/web/themes/custom/unl_five_herbie/templates/block/block--block-content-slideshow.html.twig
@@ -27,7 +27,7 @@
 #}
 {{ attach_library('unl_five_herbie/slideshow') }}
 
-<div{{ attributes.addClass('dcf-slideshow') }}>
+<div{{ attributes.addClass('dcf-slideshow').addClass('unlcms-component-spacer') }}>
     {{ title_prefix }}
     {{ title_suffix }}
 

--- a/web/themes/custom/unl_five_herbie/templates/block/block--block-content-social-media-links.html.twig
+++ b/web/themes/custom/unl_five_herbie/templates/block/block--block-content-social-media-links.html.twig
@@ -1,7 +1,8 @@
+{{ attach_library('unl_five_herbie/social_media_links') }}
 {% set attributes = attributes ?: create_attribute() %}
-{% set card_classes = [' dcf-pt-7 dcf-pb-7 unl-bg-scarlet dcf-d-flex dcf-flex-wrap dcf-ai-center dcf-jc-center dcf-row-gap-5 dcf-col-gap-8'] %}
+{% set social_media_classes = ['unlcms-component-spacer unlcms-socialmedia-component unl-bg-scarlet dcf-d-flex dcf-flex-wrap dcf-ai-center dcf-jc-center dcf-row-gap-5 dcf-col-gap-8'] %}
 
-<div{{ attributes.addclass(card_classes) }}>
+<div{{ attributes.addclass(social_media_classes) }}>
   {{ title_prefix }}
   {{ content.b_social_media_links_title }}
   {{ title_suffix }}

--- a/web/themes/custom/unl_five_herbie/templates/block/block--block-content-tabs.html.twig
+++ b/web/themes/custom/unl_five_herbie/templates/block/block--block-content-tabs.html.twig
@@ -41,7 +41,7 @@
   {% set attributes = attributes ?: create_attribute() %}
   {% set attributes = attributes.addClass(['dcf-tabs']) %}
 
-  <div{{attributes.setAttribute('id', idName) }}>
+  <div{{attributes.setAttribute('id', idName).addClass('unlcms-component-spacer')}}>
     {{ title_prefix }}
       {% if content.b_tabs_title.0 %}
       <h2>{{ content.b_tabs_title }}</h2>
@@ -50,5 +50,3 @@
     {{ content.b_tab_item }}
   </div>
 {% endblock %}
-
-

--- a/web/themes/custom/unl_five_herbie/templates/block/block--block-content-tandem.html.twig
+++ b/web/themes/custom/unl_five_herbie/templates/block/block--block-content-tandem.html.twig
@@ -1,4 +1,4 @@
-<div{{ attributes.addClass('unl-bg-cream') }}>
+<div{{ attributes.addClass('unl-bg-cream').addClass('unlcms-component-spacer') }}>
 
   {{ title_prefix }}
   {{ title_suffix }}

--- a/web/themes/custom/unl_five_herbie/templates/block/block--block-content-timeline.html.twig
+++ b/web/themes/custom/unl_five_herbie/templates/block/block--block-content-timeline.html.twig
@@ -8,9 +8,8 @@
 {% else %}
 	{% set orderedListClass = verticalListClass %}
 {% endif %}
-
-<div{{attributes}}>
-	<div class="dcf-bleed dcf-wrapper dcf-pt-9 dcf-pb-9 unl-bg-light-gray">
+<div {{attributes.addClass('unlcms-component-spacer').addClass('unlcms-timeline-component')}}>
+	<div class="dcf-bleed dcf-wrapper unlcms-component-spacer unl-bg-light-gray">
 		{% if content.b_timeline_timeline_heading %}
 			{{ title_prefix }}
 			<h2>{{content.b_timeline_timeline_heading}}</h2>

--- a/web/themes/custom/unl_five_herbie/unl_five_herbie.libraries.yml
+++ b/web/themes/custom/unl_five_herbie/unl_five_herbie.libraries.yml
@@ -43,7 +43,7 @@ card:
   version: VERSION
   css:
     theme:
-      css/theme/card.css: {}
+      css/theme/block/card.css: {}
   js:
     js/theme/card.js: {}
 
@@ -120,3 +120,15 @@ simple_media:
   css:
     theme:
       css/theme/block/simple_media.css: {}
+
+accordion:
+  version: VERSION
+  css:
+    theme:
+      css/theme/block/accordion.css: {}
+
+social_media_links:
+  version: VERSION
+  css:
+    theme:
+      css/theme/block/social_media_links.css: {}


### PR DESCRIPTION
Closes #967 

The components that will automatically add the 2em margin-top value if there are more than one component in a section are below. (If 2em is small, we can change it. That is what is currently set for cards...)

- [x] Accordion <div class="dcf-d-flex dcf-jc-center dcf-pt-9 dcf-pb-9">
- [x] Icon links <div{{ attributes.addClass('dcf-pt-9').addClass('dcf-pb-9') }}>
- [x] Logo cloud <div{{ attributes.addClass('dcf-pt-9').addClass('dcf-pb-9') }}>
- [x] Social media links dcf-pt-7 dcf-pb-7
- [x] Timeline <div class="dcf-bleed dcf-wrapper dcf-pt-9 dcf-pb-9 unl-bg-light-gray">

All margin and padding added to the outermost` <div> `in the block Twig templates for the above components have been removed.