### PR TITLE
Edit own person page code changes. Fixes #973.

### DIFF
--- a/config/sync/administerusersbyrole.settings.yml
+++ b/config/sync/administerusersbyrole.settings.yml
@@ -6,3 +6,4 @@ roles:
   site_admin: safe
   coder: safe
   administrator: perm
+  temporary_editor: unsafe

--- a/config/sync/system.action.user_add_role_action.temporary_editor.yml
+++ b/config/sync/system.action.user_add_role_action.temporary_editor.yml
@@ -1,0 +1,14 @@
+uuid: 6cad72a1-b1fa-4903-aa3f-e27f5d292d16
+langcode: en
+status: true
+dependencies:
+  config:
+    - user.role.temporary_editor
+  module:
+    - user
+id: user_add_role_action.temporary_editor
+label: 'Add the Temporary Editor role to the selected user(s)'
+type: user
+plugin: user_add_role_action
+configuration:
+  rid: temporary_editor

--- a/config/sync/system.action.user_remove_role_action.temporary_editor.yml
+++ b/config/sync/system.action.user_remove_role_action.temporary_editor.yml
@@ -1,0 +1,14 @@
+uuid: 17a79aef-9189-46fe-a865-4edaea9f52f2
+langcode: en
+status: true
+dependencies:
+  config:
+    - user.role.temporary_editor
+  module:
+    - user
+id: user_remove_role_action.temporary_editor
+label: 'Remove the Temporary Editor role from the selected user(s)'
+type: user
+plugin: user_remove_role_action
+configuration:
+  rid: temporary_editor

--- a/config/sync/user.role.temporary_editor.yml
+++ b/config/sync/user.role.temporary_editor.yml
@@ -1,0 +1,19 @@
+uuid: 7509fca5-a233-40ad-b4b1-dde1edd60287
+langcode: en
+status: true
+dependencies:
+  config:
+    - filter.format.simple
+    - filter.format.standard
+    - workflows.workflow.editorial
+  module:
+    - content_moderation
+    - filter
+id: temporary_editor
+label: 'Temporary Editor'
+weight: -2
+is_admin: null
+permissions:
+  - 'use editorial transition publish'
+  - 'use text format simple'
+  - 'use text format standard'

--- a/web/modules/custom/features/herbie_roles/config/install/user.role.temporary_editor.yml
+++ b/web/modules/custom/features/herbie_roles/config/install/user.role.temporary_editor.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - filter.format.simple
+    - filter.format.standard
+    - workflows.workflow.editorial
+  module:
+    - content_moderation
+    - filter
+id: temporary_editor
+label: 'Temporary Editor'
+weight: -2
+is_admin: null
+permissions:
+  - 'use editorial transition publish'
+  - 'use text format simple'
+  - 'use text format standard'

--- a/web/modules/custom/features/herbie_roles/herbie_roles.info.yml
+++ b/web/modules/custom/features/herbie_roles/herbie_roles.info.yml
@@ -61,5 +61,5 @@ dependencies:
   - 'webform:webform'
   - 'webform:webform_node'
   - 'webform:webform_submission_log'
-version: 1.7.1
+version: 1.7.2
 package: Herbie

--- a/web/modules/custom/unl_person/src/EventSubscriber/RequestSubscriber.php
+++ b/web/modules/custom/unl_person/src/EventSubscriber/RequestSubscriber.php
@@ -4,99 +4,158 @@ namespace Drupal\unl_person\EventSubscriber;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
-use Drupal\user\Entity\Role;
-use Drupal\user\RoleInterface;
 use Symfony\Contracts\EventDispatcher\Event;
+use Drupal\Core\Session\AccountProxyInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\user\Entity\User;
+use Drupal\path_alias\AliasManagerInterface;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Drupal\node\Entity\Node;
+use Drupal\Core\Messenger\MessengerInterface;
 
 /**
  * Event Subscriber to listen to the kernel.request event.
  */
 class RequestSubscriber implements EventSubscriberInterface {
+  protected $currentUser;
+  protected $aliasManager;
+  protected $messenger;
+  private $reload_page = false;
+  private $temporary_editor = "temporary_editor";
 
+  public function __construct(AccountProxyInterface $current_user, AliasManagerInterface $aliasManager, MessengerInterface $messenger) {
+    $this->currentUser = $current_user;
+    $this->aliasManager = $aliasManager;
+    $this->messenger = $messenger;
+  }
   /**
    * {@inheritdoc}
    */
   public static function getSubscribedEvents() {
-    // Subscribe to the request event to trigger on every page load.
-    $events[KernelEvents::REQUEST][] = 'onRequest';
+    // Subscribe to the request event to trigger on every page load after hook_node_access
+    // and routing processing, both of which run before priority 32.
+    // The priority is currently set to the default value.
+    $events = [];
+    $events[KernelEvents::REQUEST][] = ['onRequest'];
+    $events[KernelEvents::RESPONSE][] = ['onResponse'];
+
     return $events;
   }
 
   /**
-   * Event handler to check for the specific role and remove permissions.
+   * Event handler to dynamically assign user rights on the Person content type based on specific conditions.
    *
    * @param \Symfony\Component\EventDispatcher\Event $event
    *   The event object.
    */
   public function onRequest(Event $event) {
-
-    $role_name = 'authenticated';
-    $permissions_to_check = [
-      'use editorial transition publish',
-      'edit any person content',
-      'use text format simple',
-      'use text format standard',
-    ];
-
-    // Load the role.
-    $role = Role::load($role_name);
-
-    if ($role) {
-      foreach ($permissions_to_check as $permission) {
-        if ($role->hasPermission($permission)) {
-          // Revoke permissions if they were previously set to allow access.
-          user_role_revoke_permissions($role->id(), [$permission]);
-        }
-      }
-    }
-
+    $user = User::load($this->currentUser->id());
+    $current_user_roles = $user->getRoles();
     $block_id = 'unl_five_herbie_local_tasks';
     $block = \Drupal\block\Entity\Block::load($block_id);
     $visibility = $block->getVisibility();
+    $request = $event->getRequest();
+    $session = $request->getSession();
+    $route_name = $request->attributes->get('_route');
+    $entity_form = $request->attributes->get('_entity_form');
+    $node = $request->attributes->get('node');
+    $roles_to_check = ['editor', 'administrator', 'super_administrator', 'coder', 'site_admin'];
 
-    // Display the edit/view tabs for authenticated users.
+    // Display the edit/view tabs for all roles as defined in the configuration file (except Authenticated).
+    // This restores the default block configuration if there were any changes made to it.
     if (isset($visibility['user_role']['roles']['authenticated'])) {
       unset($visibility['user_role']['roles']['authenticated']);
       $block->setVisibilityConfig('user_role', $visibility['user_role']);
       $block->save();
     }
+    // If user is authenticated and has the temporary role, remove the temporary role.
+    if ($user->isAuthenticated()) {
+      if ($current_user_roles) {
+        $role_to_check = [$this->temporary_editor];
+        $role_exists = !array_diff($role_to_check, array_values($current_user_roles));
+        if ($role_exists) {
+          if ($user) {
+            $user->removeRole($this->temporary_editor);
+            $user->save();
+          }
+        }
+      }
+      // Check if the route is a "node" page (view or edit)
+      if ($entity_form == 'node.edit' || strpos($route_name, 'entity.node.') !== FALSE) {
+        // Get the node from the request.
+        if ($node && $node instanceof Node) {
+          // Check if node is a person content type and if the user does not have any of the editor/admin roles.
+          if ($node->getType() === 'person' && empty(array_intersect($roles_to_check, $current_user_roles))) {
+            if ($node->hasField('n_person_unldirectoryreference') && !$node->get('n_person_unldirectoryreference')->isEmpty()) {
+              $person_unldirectoryreference_data = $node->get('n_person_unldirectoryreference')->getValue()[0]['target_id'];
+              $person_referenced_account = user_load_by_name($person_unldirectoryreference_data);
+              // If the n_person_unldirectoryreference field has a value and it matches the current user, allow local task block/menu access.
+              if ($person_referenced_account && $person_referenced_account->id() === $user->id()) {
+                $roles_to_check = ['authenticated', $this->temporary_editor];
+                $roles_exist = !array_diff($roles_to_check, array_values($current_user_roles));
+                if (!isset($visibility['user_role']['roles']['authenticated'])) {
+                  if ($user) {
+                    // Add the temporary role to the user.
+                    $user->addRole($this->temporary_editor);
+                    $user->save();
+                    $this->reload_page = true;
+                  }
+                  // Display the edit/view tabs for authenticated users.
+                  if ($current_user_roles === ['authenticated'] || $roles_exist) {
+                    $visibility['user_role']['roles']['authenticated'] = 'authenticated';
+                    $block->setVisibilityConfig('user_role', $visibility['user_role']);
+                    $block->save();
+                  }
 
-    $request = \Drupal::service('request_stack')->getCurrentRequest();
-    $route_name = $request->attributes->get('_route');
-
-    // Check if the route is a "node" page (view or edit).
-    if (strpos($route_name, 'entity.node.') !== FALSE) {
-      // Get the node from the request.
-      $node = $request->attributes->get('node');
-      if ($node) {
-        if ($node->getType() === 'person') {
-          if ($node->hasField('n_person_unldirectoryreference') && !$node->get('n_person_unldirectoryreference')->isEmpty()) {
-            $person_unldirectoryreference_data = $node->get('n_person_unldirectoryreference')->getValue()[0]['target_id'];
-            $person_referenced_account = user_load_by_name($person_unldirectoryreference_data);
-            // If the n_person_unldirectoryreference field has a value and it matches the current user, allow access.
-            $user = \Drupal::currentUser();
-
-            if ($person_referenced_account && $person_referenced_account->id() === $user->id()) {
-              $block = \Drupal\block\Entity\Block::load($block_id);
-              $visibility = $block->getVisibility();
-              $user = \Drupal::currentUser();
-              $current_user_roles = $user->getRoles();
-              // Display the edit/view tabs for authenticated users.
-              if (!isset($visibility['user_role']['roles']['authenticated'])) {
-                if ($current_user_roles === ['authenticated']) {
-                  $visibility['user_role']['roles']['authenticated'] = 'authenticated';
-                  $block->setVisibilityConfig('user_role', $visibility['user_role']);
-                  $block->save();
+                  // Add a warning message to the user when they are on the edit page and navigate to another UNL page.
+                  if ($entity_form == 'node.edit' && strpos($route_name, 'entity.node.') !== FALSE) {
+                    $this->messenger->addWarning('Leaving this page and navigating to another logged-in UNL webpage will require a page refresh upon return to regain edit and save access. Please ensure you save your changes before leaving this edit page or keep a backup of any modifications elsewhere.');
+                  }
                 }
               }
-              user_role_grant_permissions(RoleInterface::AUTHENTICATED_ID, ['use editorial transition publish']);
-              user_role_grant_permissions(RoleInterface::AUTHENTICATED_ID, ['edit any person content']);
-              user_role_grant_permissions(RoleInterface::AUTHENTICATED_ID, ['use text format simple']);
-              user_role_grant_permissions(RoleInterface::AUTHENTICATED_ID, ['use text format standard']);
             }
           }
         }
       }
+      if ($this->reload_page === false) {
+        $this->removeSessionKey($session, 'page_reloaded');
+      }
+    }
+  }
+
+  /**
+   * Handles the kernel.response event.
+   * Reload page to sync the user roles assigned to the user so the edit tab shows up.
+   *
+   * @param \Symfony\Component\HttpKernel\Event\ResponseEvent $event
+   *
+   */
+  public function onResponse(ResponseEvent $event) {
+    $request = $event->getRequest();
+    $session = $request->getSession();
+    // Check if the page requires reloading and ensure it hasn't already been reloaded to prevent an infinite redirect loop.
+    if ($this->reload_page && !$session->has('page_reloaded')) {
+      $request = $event->getRequest();
+      $url = $request->getUri();
+      // Redirect user to the same page to reload the page.
+      $event->setResponse(new RedirectResponse($url));
+      $session->set('page_reloaded', true);
+    }
+  }
+
+  public static function create(ContainerInterface $container) {
+    return new static(
+
+      $container->get('current_user'),
+      $container->get('path.alias_manager'),
+      $container->get('messenger')
+    );
+  }
+
+  private function removeSessionKey($session, $key) {
+    if ($session->has($key)) {
+      $session->remove($key);
     }
   }
 }

--- a/web/modules/custom/unl_person/unl_person.module
+++ b/web/modules/custom/unl_person/unl_person.module
@@ -1,6 +1,10 @@
 <?php
 
 use Drupal\node\Entity\Node;
+use Drupal\node\NodeInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\user\Entity\User;
+use Drupal\Core\Form\FormStateInterface;
 
 /**
  * Implements hook_theme().
@@ -61,12 +65,106 @@ function unl_person_form_alter(&$form, $form_state, $form_id) {
   if ($form_id == "node_person_edit_form") {
     $user = \Drupal::currentUser();
     $current_user_roles = $user->getRoles();
-    $allowed_roles = ['authenticated', 'viewer'];
+    $allowed_roles = ['authenticated', 'viewer', 'temporary_editor'];
 
     // Disable entitygroup and unldirectoryreference fields
     if (array_diff($current_user_roles, $allowed_roles) === [] && count($current_user_roles) <= count($allowed_roles)) {
       $form['n_person_unldirectoryreference']['widget']['#disabled'] = TRUE;
       $form['entitygroupfield']['#disabled'] = TRUE;
+    }
+  }
+}
+
+/**
+ * Implements hook_node_access().
+ * Checks if the user has access to edit a person node.
+ */
+function unl_person_node_access(NodeInterface $node, $operation, AccountInterface $account) {
+  // Make sure this only applies to authenticated users not other roles like super admin or editor roles
+  $current_node = \Drupal::routeMatch()->getParameter('node');
+  if ($current_node instanceof Node && $current_node->id() === $node->id()) {
+    $roles_to_check = ['editor', 'administrator', 'super_administrator', 'coder', 'site_admin'];
+    if (empty(array_intersect($roles_to_check, $account->getRoles()))) {
+      if ($node->getType() === 'person' && $account->isAuthenticated()) {
+        if ($operation === 'update') {
+          if (__unl_person_user_has_edit_access($account, $current_node)) {
+            return \Drupal\Core\Access\AccessResult::allowed();
+          }
+        }
+        if ($operation === 'view') {
+          if (__unl_person_user_has_edit_access($account, $current_node)) {
+            return \Drupal\Core\Access\AccessResult::allowed();
+          }
+        }
+      }
+      return \Drupal\Core\Access\AccessResult::neutral();
+    }
+  }
+  return \Drupal\Core\Access\AccessResult::allowed();
+}
+
+/**
+ * Check if the user has access to edit a person node.
+ */
+
+function __unl_person_user_has_edit_access(AccountInterface $account, NodeInterface $node) {
+  $request = \Drupal::request();
+  $session = $request->getSession();
+  $current_user_roles = $account->getRoles();
+  $roles_to_check = ['authenticated', 'temporary_editor', 'viewer'];
+  $user = User::load($account->id());
+  $role_name = 'temporary_editor';
+
+  $current_user_roles_check = empty(array_diff(array_values($current_user_roles), $roles_to_check,));
+  if ($current_user_roles === ['authenticated'] ||  $current_user_roles_check) {
+    if ($node->getType() === 'person') {
+      if ($node->hasField('n_person_unldirectoryreference') && !$node->get('n_person_unldirectoryreference')->isEmpty()) {
+        $person_unldirectoryreference_data = $node->get('n_person_unldirectoryreference')->getValue()[0]['target_id'];
+        $person_referenced_account = user_load_by_name($person_unldirectoryreference_data);
+        // If the n_person_unldirectoryreference field has a value and it matches the current user, allow access.
+        if ($person_referenced_account && $person_referenced_account->id() === $account->id()) {
+          if ($user) {
+            // Add the temporary role to the user.
+            $user->addRole($role_name);
+            $user->save();          }
+          return true;
+        }
+      }
+    }
+  }
+  return false;
+}
+
+/**
+ * Remove any lingering temporary roles from users.
+ */
+function unl_person_cron() {
+  $role_to_remove = 'temporary_editor'; // Replace with the actual role machine name
+
+  $query = \Drupal::entityQuery('user')
+    ->condition('roles', $role_to_remove);
+  $uids = $query->execute();
+
+  if (!empty($uids)) {
+    $users = \Drupal\user\Entity\User::loadMultiple($uids);
+    foreach ($users as $user) {
+      $user->removeRole($role_to_remove);
+      $user->save();
+    }
+    \Drupal::logger('unl_person')->notice("Role '$role_to_remove' removed from all users.");
+  }
+}
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ */
+function unl_person_form_views_exposed_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  // Remove certain roles from the views exposed filter on /admin/people.
+  $view = $form_state->get('view');
+  if ($view && $view->id() === 'administerusersbyrole_people') {
+    if (!User::load(\Drupal::currentUser()->id())->hasRole('administrator') &&
+      !User::load(\Drupal::currentUser()->id())->hasRole('super_administrator')) {
+      unset($form['role']['#options']['temporary_editor']);
     }
   }
 }

--- a/web/modules/custom/unl_person/unl_person.services.yml
+++ b/web/modules/custom/unl_person/unl_person.services.yml
@@ -1,5 +1,6 @@
 services:
   unl_person.request_subscriber:
     class: Drupal\unl_person\EventSubscriber\RequestSubscriber
+    arguments: ['@current_user', '@path_alias.manager', '@messenger']
     tags:
       - { name: event_subscriber }

--- a/web/profiles/herbie/herbie.install
+++ b/web/profiles/herbie/herbie.install
@@ -1,5 +1,5 @@
 <?php
-
+use Drupal\user\Entity\Role;
 /**
  * Implements hook_install_tasks().
  *
@@ -119,5 +119,20 @@ function herbie_update_8106(&$sandbox) {
       $node->get('n_person_bio')->format = 'standard';
       $node->save();
     }
+  }
+}
+
+
+/**
+ * Update the authenticated role if it has a specific permission.
+ */
+function herbie_update_8107(&$sandbox) {
+  $role_name = 'authenticated';
+  $permission = 'edit any person content';
+  $role = Role::load(id: $role_name);
+
+  if ($role && $role->hasPermission($permission)) {
+    $role->revokePermission($permission);
+    $role->save();
   }
 }


### PR DESCRIPTION
Closes #973

There are a couple of system action files in the config/sync folder that didn’t export to the config/install folder by default. I can manually create these files and add them to the config/install folder if that's okay.

This change won’t work for group person pages due to the permission and access logic set by the Group Module
.