### PR TITLE
Changed the way LinkedIn usernames are retrieved and added URL validation. Fixes #974.

### DIFF
--- a/config/sync/field.field.block_content.social_media_links.b_social_media_links_linkedin.yml
+++ b/config/sync/field.field.block_content.social_media_links.b_social_media_links_linkedin.yml
@@ -12,7 +12,7 @@ field_name: b_social_media_links_linkedin
 entity_type: block_content
 bundle: social_media_links
 label: Linkedin
-description: "Only enter everything after 'https://www.linkedin.com/ln' from your LinkedIn profile's URL address."
+description: "Only enter everything after 'https://www.linkedin.com/' from your LinkedIn profile's URL address."
 required: false
 translatable: false
 default_value: {  }

--- a/config/sync/field.field.paragraph.contact_info_social_media.p_b_cinfo_sm_linkedin.yml
+++ b/config/sync/field.field.paragraph.contact_info_social_media.p_b_cinfo_sm_linkedin.yml
@@ -10,7 +10,7 @@ field_name: p_b_cinfo_sm_linkedin
 entity_type: paragraph
 bundle: contact_info_social_media
 label: LinkedIn
-description: "Only enter everything after 'https://www.linkedin.com/ln' from your LinkedIn profile's URL address."
+description: "Only enter everything after 'https://www.linkedin.com/' from your LinkedIn profile's URL address."
 required: false
 translatable: false
 default_value: {  }

--- a/web/modules/custom/features/herbie_builder_page/config/install/field.field.block_content.social_media_links.b_social_media_links_linkedin.yml
+++ b/web/modules/custom/features/herbie_builder_page/config/install/field.field.block_content.social_media_links.b_social_media_links_linkedin.yml
@@ -9,7 +9,7 @@ field_name: b_social_media_links_linkedin
 entity_type: block_content
 bundle: social_media_links
 label: Linkedin
-description: "Only enter everything after 'https://www.linkedin.com/ln' from your LinkedIn profile's URL address."
+description: "Only enter everything after 'https://www.linkedin.com/' from your LinkedIn profile's URL address."
 required: false
 translatable: false
 default_value: {  }

--- a/web/modules/custom/features/herbie_builder_page/config/install/field.field.paragraph.contact_info_social_media.p_b_cinfo_sm_linkedin.yml
+++ b/web/modules/custom/features/herbie_builder_page/config/install/field.field.paragraph.contact_info_social_media.p_b_cinfo_sm_linkedin.yml
@@ -9,7 +9,7 @@ field_name: p_b_cinfo_sm_linkedin
 entity_type: paragraph
 bundle: contact_info_social_media
 label: LinkedIn
-description: "Only enter everything after 'https://www.linkedin.com/ln' from your LinkedIn profile's URL address."
+description: "Only enter everything after 'https://www.linkedin.com/' from your LinkedIn profile's URL address."
 required: false
 translatable: false
 default_value: {  }

--- a/web/modules/custom/features/herbie_builder_page/herbie_builder_page.info.yml
+++ b/web/modules/custom/features/herbie_builder_page/herbie_builder_page.info.yml
@@ -77,5 +77,5 @@ dependencies:
   - 'unl_news:unl_news'
   - 'webform:webform'
   - 'webform:webform_submission_log'
-version: 1.9.2
+version: 1.9.3
 package: Herbie

--- a/web/themes/custom/unl_five_herbie/templates/block/block--block-content-social-media-links.html.twig
+++ b/web/themes/custom/unl_five_herbie/templates/block/block--block-content-social-media-links.html.twig
@@ -51,7 +51,10 @@
       {% if content.b_social_media_links_linkedin[0]['#context']['value'] %}
       <li class="dcf-mb-0">
         {% set filtered_username_input =  content.b_social_media_links_linkedin[0]['#context']['value']|url_encode %}
-        <a class="dcf-d-block dcf-h-6 dcf-w-6 unl-cream" href="https://www.linkedin.com/in/{{filtered_username_input}}" aria-label="Our LinkedIn profile">
+        {% set filtered_username_input = preg_replace('/%2F/', '/', filtered_username_input) %}
+        {# As of this time, LinkedIn doesn't define URL patterns for profiles (no official documentation).
+           We ask for everything after "linkedin.com/" and append it to the base URL. #}
+        <a class="dcf-d-block dcf-h-6 dcf-w-6 unl-cream" href="https://www.linkedin.com/{{filtered_username_input}}" aria-label="Our LinkedIn profile">
           <svg class="dcf-h-100% dcf-w-100% dcf-fill-current" focusable="false" height="16" width="16" viewBox="0 0 48 48">
             <path d="M44.45 0H3.54A3.5 3.5 0 0 0 0 3.46v41.08A3.5 3.5 0 0 0 3.54 48h40.91A3.51 3.51 0 0 0 48 44.54V3.46A3.51 3.51 0 0 0 44.45 0zM14.24 40.9H7.11V18h7.13zm-3.56-26a4.13 4.13 0 1 1 4.13-4.13 4.13 4.13 0 0 1-4.13 4.1zm30.23 26h-7.12V29.76c0-2.66 0-6.07-3.7-6.07s-4.27 2.9-4.27 5.88V40.9h-7.11V18h6.82v3.13h.1a7.48 7.48 0 0 1 6.74-3.7c7.21 0 8.54 4.74 8.54 10.91z"></path>
           </svg>

--- a/web/themes/custom/unl_five_herbie/templates/node/node--person--full.html.twig
+++ b/web/themes/custom/unl_five_herbie/templates/node/node--person--full.html.twig
@@ -246,6 +246,9 @@
                       {% if node.n_person_social_linkedin.value %}
                         <dd class="dcf-d-inline-block dcf-pt-4 dcf-pr-3">
                           {% set filtered_username_input = node.n_person_social_linkedin.value|url_encode %}
+                          {% set filtered_username_input = preg_replace('/%2F/', '/', filtered_username_input) %}
+                          {# As of this time, LinkedIn doesn't define URL patterns for profiles (no official documentation).
+                          We ask for everything after "linkedin.com/" and append it to the base URL. #}
                           <a class="dcf-d-block dcf-h-6 dcf-w-6" href="https://www.linkedin.com/{{filtered_username_input}}" aria-label="{{ label }} on LinkedIn">
                             <svg class="dcf-h-100% dcf-w-100% dcf-fill-current" focusable="false" height="16" width="16" viewbox="0 0 48 48">
                               <path d="M44.45 0H3.54A3.5 3.5 0 0 0 0 3.46v41.08A3.5 3.5 0 0 0 3.54 48h40.91A3.51 3.51 0 0 0 48 44.54V3.46A3.51 3.51 0 0 0 44.45 0zM14.24 40.9H7.11V18h7.13zm-3.56-26a4.13 4.13 0 1 1 4.13-4.13 4.13 4.13 0 0 1-4.13 4.1zm30.23 26h-7.12V29.76c0-2.66 0-6.07-3.7-6.07s-4.27 2.9-4.27 5.88V40.9h-7.11V18h6.82v3.13h.1a7.48 7.48 0 0 1 6.74-3.7c7.21 0 8.54 4.74 8.54 10.91z"></path>

--- a/web/themes/custom/unl_five_herbie/templates/node/node--person--teaser.html.twig
+++ b/web/themes/custom/unl_five_herbie/templates/node/node--person--teaser.html.twig
@@ -296,7 +296,10 @@
               {% if node.n_person_social_linkedin.value %}
                 <dd class="dcf-d-inline-block dcf-pt-4 dcf-pr-3">
                   {% set filtered_username_input =  node.n_person_social_linkedin.value|url_encode %}
-                  <a class="dcf-d-block dcf-h-6 dcf-w-6" href="https://www.linkedin.com/in/{{filtered_username_input}}" aria-label="{{node.n_person_social_linkedin.value}} on LinkedIn">
+                  {% set filtered_username_input = preg_replace('/%2F/', '/', filtered_username_input) %}
+                  {# As of this time, LinkedIn doesn't define URL patterns for profiles (no official documentation).
+                   We ask for everything after "linkedin.com/" and append it to the base URL. #}
+                  <a class="dcf-d-block dcf-h-6 dcf-w-6" href="https://www.linkedin.com/{{filtered_username_input}}" aria-label="{{node.n_person_social_linkedin.value}} on LinkedIn">
                     <svg class="dcf-h-100% dcf-w-100% dcf-fill-current" focusable="false" height="16" width="16" viewbox="0 0 48 48">
                       <path d="M44.45 0H3.54A3.5 3.5 0 0 0 0 3.46v41.08A3.5 3.5 0 0 0 3.54 48h40.91A3.51 3.51 0 0 0 48 44.54V3.46A3.51 3.51 0 0 0 44.45 0zM14.24 40.9H7.11V18h7.13zm-3.56-26a4.13 4.13 0 1 1 4.13-4.13 4.13 4.13 0 0 1-4.13 4.1zm30.23 26h-7.12V29.76c0-2.66 0-6.07-3.7-6.07s-4.27 2.9-4.27 5.88V40.9h-7.11V18h6.82v3.13h.1a7.48 7.48 0 0 1 6.74-3.7c7.21 0 8.54 4.74 8.54 10.91z"></path>
                     </svg>

--- a/web/themes/custom/unl_five_herbie/templates/paragraph/paragraph--contact-info-social-media--default.html.twig
+++ b/web/themes/custom/unl_five_herbie/templates/paragraph/paragraph--contact-info-social-media--default.html.twig
@@ -99,7 +99,10 @@
         {% if content.p_b_cinfo_sm_linkedin.0 %}
           <dd class="dcf-d-inline-block dcf-pt-4 dcf-pr-3">
             {% set filtered_username_input = content.p_b_cinfo_sm_linkedin.0['#context'].value|url_encode %}
-            <a class="dcf-d-block dcf-h-6 dcf-w-6" href="https://www.linkedin.com/in/{{filtered_username_input}}" aria-label="LinkedIn">
+            {% set filtered_username_input = preg_replace('/%2F/', '/', filtered_username_input) %}
+            {# As of this time, LinkedIn doesn't define URL patterns for profiles (no official documentation).
+            We ask for everything after "linkedin.com/" and append it to the base URL. #}
+            <a class="dcf-d-block dcf-h-6 dcf-w-6" href="https://www.linkedin.com/{{filtered_username_input}}" aria-label="LinkedIn">
               <svg class="dcf-h-100% dcf-w-100% dcf-fill-current" focusable="false" height="16" width="16" viewbox="0 0 48 48">
                 <path d="M44.45 0H3.54A3.5 3.5 0 0 0 0 3.46v41.08A3.5 3.5 0 0 0 3.54 48h40.91A3.51 3.51 0 0 0 48 44.54V3.46A3.51 3.51 0 0 0 44.45 0zM14.24 40.9H7.11V18h7.13zm-3.56-26a4.13 4.13 0 1 1 4.13-4.13 4.13 4.13 0 0 1-4.13 4.1zm30.23 26h-7.12V29.76c0-2.66 0-6.07-3.7-6.07s-4.27 2.9-4.27 5.88V40.9h-7.11V18h6.82v3.13h.1a7.48 7.48 0 0 1 6.74-3.7c7.21 0 8.54 4.74 8.54 10.91z"></path>
               </svg>


### PR DESCRIPTION
Closes #974 
Closes #976 
Closes #969 

The builder page feature needs to be run for currently live sites, as the description for entering a LinkedIn profile URL address has changed.