### PR TITLE
Added MathJax Drupal Module. Fixes #936.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -189,6 +189,7 @@
         "drupal/linkit": "^6.0",
         "drupal/linkit_media_library": "^1.0@alpha",
         "drupal/markup": "^2.0@beta",
+        "drupal/mathjax": "^4.1",
         "drupal/media_entity_file_replace": "^1.1",
         "drupal/media_file_delete": "^1.3",
         "drupal/memcache": "^2.7",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1623d0e8d2b7569f885244d631736e28",
+    "content-hash": "c7f89a99369bf05db9e386490bae3830",
     "packages": [
         {
             "name": "arthurkushman/query-path",
@@ -5845,6 +5845,58 @@
             "homepage": "https://www.drupal.org/project/markup",
             "support": {
                 "source": "https://git.drupalcode.org/project/markup"
+            }
+        },
+        {
+            "name": "drupal/mathjax",
+            "version": "4.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/mathjax.git",
+                "reference": "4.1.0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/mathjax-4.1.0.zip",
+                "reference": "4.1.0",
+                "shasum": "f7b3fe1e07ea2d0fa5133953497328cc4943ec12"
+            },
+            "require": {
+                "drupal/core": "^9.1 || ^10 || ^11"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "4.1.0",
+                    "datestamp": "1724272614",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "cilefen",
+                    "homepage": "https://www.drupal.org/user/1850070"
+                },
+                {
+                    "name": "joelpittet",
+                    "homepage": "https://www.drupal.org/user/160302"
+                },
+                {
+                    "name": "julou",
+                    "homepage": "https://www.drupal.org/user/273952"
+                }
+            ],
+            "description": "Javascript-based LaTeX rendering solution for your Drupal website.",
+            "homepage": "https://www.drupal.org/project/mathjax",
+            "support": {
+                "source": "https://git.drupalcode.org/project/mathjax"
             }
         },
         {

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -113,6 +113,7 @@ module:
   linkit: 0
   linkit_media_library: 0
   markup: 0
+  mathjax: 0
   media: 0
   media_entity_file_replace: 0
   media_file_delete: 0

--- a/config/sync/filter.format.standard.yml
+++ b/config/sync/filter.format.standard.yml
@@ -10,6 +10,7 @@ dependencies:
     - dcf_ckeditor5
     - editor
     - linkit
+    - mathjax
     - media
 _core:
   default_config_hash: 5anSBiLTqs4dOkhLlIFIaJ8nZp-aMBQXtZ42IK2ONWo
@@ -113,3 +114,9 @@ filters:
     weight: 0
     settings:
       dcftable: '1'
+  filter_mathjax:
+    id: filter_mathjax
+    provider: mathjax
+    status: true
+    weight: 50
+    settings: {  }

--- a/config/sync/mathjax.settings.yml
+++ b/config/sync/mathjax.settings.yml
@@ -1,0 +1,7 @@
+_core:
+  default_config_hash: UOFmZIwiZl6qJ50XXrC2r_F26ZTYR_3-d93LAnL8J4w
+use_cdn: 1
+cdn_url: 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML'
+config_type: 0
+default_config_string: '{"tex2jax":{"inlineMath":[["$","$"],["\\(","\\)"]],"processEscapes":"true"},"showProcessingMessages":"false","messageStyle":"none"}'
+enable_for_admin: 0

--- a/config/sync/user.role.administrator.yml
+++ b/config/sync/user.role.administrator.yml
@@ -45,6 +45,7 @@ dependencies:
     - group
     - key
     - layout_builder
+    - mathjax
     - media
     - media_file_delete
     - menu_admin_per_menu
@@ -112,6 +113,7 @@ permissions:
   - 'administer key configuration overrides'
   - 'administer keys'
   - 'administer main menu items'
+  - 'administer mathjax'
   - 'administer meta tags'
   - 'administer node display'
   - 'administer node fields'

--- a/web/modules/custom/features/herbie_builder_page/config/install/filter.format.standard.yml
+++ b/web/modules/custom/features/herbie_builder_page/config/install/filter.format.standard.yml
@@ -9,6 +9,7 @@ dependencies:
     - dcf_ckeditor5
     - editor
     - linkit
+    - mathjax
     - media
 name: Standard
 format: standard
@@ -110,3 +111,9 @@ filters:
     weight: 0
     settings:
       dcftable: '1'
+  filter_mathjax:
+    id: filter_mathjax
+    provider: mathjax
+    status: true
+    weight: 50
+    settings: {  }

--- a/web/modules/custom/features/herbie_builder_page/herbie_builder_page.info.yml
+++ b/web/modules/custom/features/herbie_builder_page/herbie_builder_page.info.yml
@@ -64,6 +64,7 @@ dependencies:
   - 'lb_direct_add:lb_direct_add'
   - 'linkit:linkit'
   - 'markup:markup'
+  - 'mathjax:mathjax'
   - 'menu_block:menu_block'
   - 'oembed_providers:oembed_providers'
   - 'paragraphs:paragraphs'
@@ -77,5 +78,5 @@ dependencies:
   - 'unl_news:unl_news'
   - 'webform:webform'
   - 'webform:webform_submission_log'
-version: 1.9.3
+version: 1.9.4
 package: Herbie

--- a/web/modules/custom/features/herbie_config/config/install/mathjax.settings.yml
+++ b/web/modules/custom/features/herbie_config/config/install/mathjax.settings.yml
@@ -1,0 +1,5 @@
+use_cdn: 1
+cdn_url: 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML'
+config_type: 0
+default_config_string: '{"tex2jax":{"inlineMath":[["$","$"],["\\(","\\)"]],"processEscapes":"true"},"showProcessingMessages":"false","messageStyle":"none"}'
+enable_for_admin: 0

--- a/web/modules/custom/features/herbie_config/herbie_config.features.yml
+++ b/web/modules/custom/features/herbie_config/herbie_config.features.yml
@@ -5,6 +5,7 @@ required:
   - entity_usage.settings
   - google_tag.settings
   - moderated_content_bulk_publish.settings
+  - mathjax.settings
   - views.view.content
   - system.action.draft_current
   - system.action.pin

--- a/web/modules/custom/features/herbie_config/herbie_config.info.yml
+++ b/web/modules/custom/features/herbie_config/herbie_config.info.yml
@@ -2,12 +2,16 @@ name: 'Herbie config'
 description: 'A bundle of miscellaneous configuration files, mainly to override default configuration in modules or other settings. '
 type: module
 core_version_requirement: '^9.4 || ^10'
-version: '1.4'
+version: '1.5'
 package: Herbie
 dependencies:
   - 'drupal:node'
+  - 'drupal:system'
+  - 'drupal:user'
+  - 'drupal:views'
   - 'entity_usage:entity_usage'
   - 'google_tag:google_tag'
-  - 'moderated_content_bulk_publish:moderated_content_bulk_publish'
   - 'linkit:linkit'
+  - 'mathjax:mathjax'
+  - 'moderated_content_bulk_publish:moderated_content_bulk_publish'
   - 'replicate_ui:replicate_ui'

--- a/web/modules/custom/features/herbie_roles/config/install/user.role.administrator.yml
+++ b/web/modules/custom/features/herbie_roles/config/install/user.role.administrator.yml
@@ -44,6 +44,7 @@ dependencies:
     - group
     - key
     - layout_builder
+    - mathjax
     - media
     - media_file_delete
     - menu_admin_per_menu
@@ -109,6 +110,7 @@ permissions:
   - 'administer key configuration overrides'
   - 'administer keys'
   - 'administer main menu items'
+  - 'administer mathjax'
   - 'administer meta tags'
   - 'administer node display'
   - 'administer node fields'

--- a/web/modules/custom/features/herbie_roles/herbie_roles.info.yml
+++ b/web/modules/custom/features/herbie_roles/herbie_roles.info.yml
@@ -41,6 +41,7 @@ dependencies:
   - 'herbie_webform:herbie_webform'
   - 'honeypot:honeypot'
   - 'key:key'
+  - 'mathjax:mathjax'
   - 'media_file_delete:media_file_delete'
   - 'menu_admin_per_menu:menu_admin_per_menu'
   - 'metatag:metatag'
@@ -61,5 +62,5 @@ dependencies:
   - 'webform:webform'
   - 'webform:webform_node'
   - 'webform:webform_submission_log'
-version: 1.7.2
+version: 1.7.3
 package: Herbie


### PR DESCRIPTION
This module adds a MathJax filter to a text format. I have enabled that filter on the Standard text format. Based on the module's README, "the default math delimiters are `$$...$$` and `\[...\]` for displayed mathematics, and
 `$...$` and `\(...\)` for in-line mathematics."
 
 Closes #936 