### PR TITLE
Added the Groups temporary role and synchronized it with the global role. Updated the code to fix a bug that prevented overriding an existing image. Fixes #1020.

### DIFF
--- a/config/sync/group.role.group_subsite-temporary_editor.yml
+++ b/config/sync/group.role.group_subsite-temporary_editor.yml
@@ -1,0 +1,16 @@
+uuid: d59e1892-a8c5-47c7-b055-17fd2743b4c5
+langcode: en
+status: true
+dependencies:
+  config:
+    - group.type.group_subsite
+    - user.role.temporary_editor
+id: group_subsite-temporary_editor
+label: 'Temporary Editor'
+weight: -2
+admin: false
+scope: outsider
+global_role: temporary_editor
+group_type: group_subsite
+permissions:
+  - 'update any group_node:person entity'

--- a/web/modules/custom/features/herbie_group/config/install/group.role.group_subsite-temporary_editor.yml
+++ b/web/modules/custom/features/herbie_group/config/install/group.role.group_subsite-temporary_editor.yml
@@ -1,0 +1,15 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - group.type.group_subsite
+    - user.role.temporary_editor
+id: group_subsite-temporary_editor
+label: 'Temporary Editor'
+weight: -2
+admin: false
+scope: outsider
+global_role: temporary_editor
+group_type: group_subsite
+permissions:
+  - 'update any group_node:person entity'

--- a/web/modules/custom/features/herbie_group/herbie_group.info.yml
+++ b/web/modules/custom/features/herbie_group/herbie_group.info.yml
@@ -22,5 +22,5 @@ dependencies:
   - 'herbie_person:herbie_person'
   - 'herbie_roles:herbie_roles'
   - 'inline_entity_form:inline_entity_form'
-version: 1.1.1
+version: 1.1.2
 package: Herbie

--- a/web/modules/custom/unl_person/src/EventSubscriber/RequestSubscriber.php
+++ b/web/modules/custom/unl_person/src/EventSubscriber/RequestSubscriber.php
@@ -61,6 +61,28 @@ class RequestSubscriber implements EventSubscriberInterface {
     $entity_form = $request->attributes->get('_entity_form');
     $node = $request->attributes->get('node');
     $roles_to_check = ['editor', 'administrator', 'super_administrator', 'coder', 'site_admin'];
+    $image_upload_route = false;
+
+    // Check if logged in user is referenced on the Person page.
+    $curent_user_is_referenced = function () use ($node, $roles_to_check, $current_user_roles, $user, $entity_form, $route_name, $request) {
+      if ($entity_form == 'node.edit' || strpos($route_name, 'entity.node.') !== FALSE) {
+        if ($node->getType() === 'person' && empty(array_intersect($roles_to_check, $current_user_roles))) {
+          if ($node->hasField('n_person_unldirectoryreference') && !$node->get('n_person_unldirectoryreference')->isEmpty()) {
+            $person_unldirectoryreference_data = $node->get('n_person_unldirectoryreference')->getValue()[0]['target_id'];
+            $person_referenced_account = user_load_by_name($person_unldirectoryreference_data);
+            if ($person_referenced_account && $person_referenced_account->id() === $user->id()) {
+              return true;
+            }
+          }
+        }
+      }
+    };
+    $curent_user_is_referenced = $curent_user_is_referenced();
+
+    // User adding an image to an image field on a node.
+    if ($route_name === "image.style_public") {
+      $image_upload_route = true;
+    }
 
     // Display the edit/view tabs for all roles as defined in the configuration file (except Authenticated).
     // This restores the default block configuration if there were any changes made to it.
@@ -74,8 +96,9 @@ class RequestSubscriber implements EventSubscriberInterface {
       if ($current_user_roles) {
         $role_to_check = [$this->temporary_editor];
         $role_exists = !array_diff($role_to_check, array_values($current_user_roles));
-        if ($role_exists) {
-          if ($user) {
+        if ($role_exists && $curent_user_is_referenced !== true) {
+          // Remove the temporary role from the user, but keep any existing roles if they're on an image upload route, as they could potentially be uploading an image for a person page.
+          if ($user && $image_upload_route === false) {
             $user->removeRole($this->temporary_editor);
             $user->save();
           }
@@ -85,34 +108,29 @@ class RequestSubscriber implements EventSubscriberInterface {
       if ($entity_form == 'node.edit' || strpos($route_name, 'entity.node.') !== FALSE) {
         // Get the node from the request.
         if ($node && $node instanceof Node) {
-          // Check if node is a person content type and if the user does not have any of the editor/admin roles.
-          if ($node->getType() === 'person' && empty(array_intersect($roles_to_check, $current_user_roles))) {
-            if ($node->hasField('n_person_unldirectoryreference') && !$node->get('n_person_unldirectoryreference')->isEmpty()) {
-              $person_unldirectoryreference_data = $node->get('n_person_unldirectoryreference')->getValue()[0]['target_id'];
-              $person_referenced_account = user_load_by_name($person_unldirectoryreference_data);
-              // If the n_person_unldirectoryreference field has a value and it matches the current user, allow local task block/menu access.
-              if ($person_referenced_account && $person_referenced_account->id() === $user->id()) {
-                $roles_to_check = ['authenticated', $this->temporary_editor];
-                $roles_exist = !array_diff($roles_to_check, array_values($current_user_roles));
-                if (!isset($visibility['user_role']['roles']['authenticated'])) {
-                  if ($user) {
-                    // Add the temporary role to the user.
-                    $user->addRole($this->temporary_editor);
-                    $user->save();
-                    $this->reload_page = true;
-                  }
-                  // Display the edit/view tabs for authenticated users.
-                  if ($current_user_roles === ['authenticated'] || $roles_exist) {
-                    $visibility['user_role']['roles']['authenticated'] = 'authenticated';
-                    $block->setVisibilityConfig('user_role', $visibility['user_role']);
-                    $block->save();
-                  }
+          $role_to_check = [$this->temporary_editor];
+          $role_exists = !array_diff($role_to_check, array_values($current_user_roles));
+          if ($curent_user_is_referenced === true) {
+            // Check if node is a person content type and if the user does not have any of the editor/admin roles.
+            $roles_to_check = ['authenticated', $this->temporary_editor];
+            $roles_exist = !array_diff($roles_to_check, array_values($current_user_roles));
+            if (!isset($visibility['user_role']['roles']['authenticated'])) {
+              // Assign the temporary role to the user, provided the role is not already assigned.
+              if ($user && empty($role_exists)) {
+                $user->addRole($this->temporary_editor);
+                $user->save();
+                $this->reload_page = true;
+              }
+              // Display the edit/view tabs for authenticated users.
+              if ($current_user_roles === ['authenticated'] || $roles_exist) {
+                $visibility['user_role']['roles']['authenticated'] = 'authenticated';
+                $block->setVisibilityConfig('user_role', $visibility['user_role']);
+                $block->save();
+              }
 
-                  // Add a warning message to the user when they are on the edit page and navigate to another UNL page.
-                  if ($entity_form == 'node.edit' && strpos($route_name, 'entity.node.') !== FALSE) {
-                    $this->messenger->addWarning('Leaving this page and navigating to another logged-in UNL webpage will require a page refresh upon return to regain edit and save access. Please ensure you save your changes before leaving this edit page or keep a backup of any modifications elsewhere.');
-                  }
-                }
+              // Add a warning message to the user when they are on the edit page and navigate to another UNL page.
+              if ($entity_form == 'node.edit' && strpos($route_name, 'entity.node.') !== FALSE) {
+                $this->messenger->addWarning('Leaving this page and navigating to another logged-in UNL webpage will require a page refresh upon return to regain edit and save access. Please make sure to save your changes before leaving this edit page, or keep a backup of any modifications in another location.');
               }
             }
           }

--- a/web/modules/custom/unl_person/unl_person.module
+++ b/web/modules/custom/unl_person/unl_person.module
@@ -123,10 +123,6 @@ function __unl_person_user_has_edit_access(AccountInterface $account, NodeInterf
         $person_referenced_account = user_load_by_name($person_unldirectoryreference_data);
         // If the n_person_unldirectoryreference field has a value and it matches the current user, allow access.
         if ($person_referenced_account && $person_referenced_account->id() === $account->id()) {
-          if ($user) {
-            // Add the temporary role to the user.
-            $user->addRole($role_name);
-            $user->save();          }
           return true;
         }
       }


### PR DESCRIPTION
Closes #1020 

Refactored the code to prevent reloading the page if a person already has the temporary editor role. Reloading the person edit interface was causing uploaded images not to be uploaded anymore. Added a Group role called 'Temporary Editor' and synced it with the global temporary editor role. The Group role has the 'Can edit any person page' permission enabled; However, the global temporary role does not. It would be great to test further on test servers. There are some things I wasn't able to test locally. For example, if I weren't the creator of the group's person page (including the group), even if I removed myself as a group member/admin, would things have changed?