### PR TITLE
Add preprocessed total_results variable since Drupal doesn’t always i…

### DIFF
--- a/web/themes/custom/unl_five_herbie/templates/view/views-view--taxonomy-term--tagged-news-items-block.html.twig
+++ b/web/themes/custom/unl_five_herbie/templates/view/views-view--taxonomy-term--tagged-news-items-block.html.twig
@@ -5,7 +5,8 @@
     'view-id-' ~ id,
     'view-display-id-' ~ display_id,
     dom_id ? 'js-view-dom-id-' ~ dom_id,
-    'dcf-mt-8'
+    'dcf-mt-8',
+    'dcf-mb-8'
   ]
 %}
 <div{{ attributes.addClass(classes).setAttribute('id', 'news-'~ dom_id) }}>
@@ -28,10 +29,16 @@
 
   {{ pager }}
   {{ attachment_after }}
-  {% if view.total_rows > 12 and more %}
+
+  {% if preprocessed_total_rows > 12 and more %}
     <div class="dcf-d-flex dcf-jc-flex-end">
       <a class="dcf-btn dcf-btn-secondary dcf-capitalize" href="{{more['#url'].toString}}news">More news</a>
     </div>
+  {% elseif preprocessed_total_rows > 12 %}
+    <div class="dcf-d-flex dcf-jc-flex-end">
+      <a class="dcf-btn dcf-btn-secondary dcf-capitalize" href="{{path('<current>')}}news">More news</a>
+    </div>
+
   {% endif %}
   {% if footer %}
     {{ footer }}

--- a/web/themes/custom/unl_five_herbie/unl_five_herbie.theme
+++ b/web/themes/custom/unl_five_herbie/unl_five_herbie.theme
@@ -512,6 +512,38 @@ function unl_five_herbie_preprocess_layout(&$variables) {
 }
 
 /**
+ * Implements template_preprocess_views_view.
+ */
+function unl_five_herbie_preprocess_views_view(&$variables) {
+  // Add preprocessed total rows to taxonomy_term view (tagged_news_items_block)
+  // since total rows only counts current page, not total tagged items.
+  if ($variables['view']->id() === 'taxonomy_term' && $variables['view']->current_display === 'tagged_news_items_block') {
+   try {
+      // Load a fresh instance of the view.
+      $full_view = Views::getView('taxonomy_term');
+      if (!$full_view) {
+        return;
+      }
+      // Set the display and remove pagination limit.
+      $full_view->setDisplay('tagged_news_items_block');
+      $full_view->setItemsPerPage(0);
+      // Pass any contextual arguments from the original view.
+      if (!empty($variables['view']->args)) {
+        $full_view->setArguments($variables['view']->args);
+      }
+      // Execute the view.
+      $full_view->preExecute();
+      $full_view->execute();
+      // Add results to template variables to be used in Twig.
+      $variables['preprocessed_total_rows'] = $full_view->total_rows ?: count($full_view->result);
+
+    } catch (\Exception $e) {
+      \Drupal::logger('unl_six_herbie_preprocess_views_view')->error('Error processing view: @message', ['@message' => $e->getMessage()]);
+    }
+  }
+}
+
+/**
  * Implements template_preprocess_views_view_fields().
  */
 function unl_five_herbie_preprocess_views_view_fields(&$variables) {

--- a/web/themes/custom/unl_six_herbie/templates/view/views-view--taxonomy-term--tagged-news-items-block.html.twig
+++ b/web/themes/custom/unl_six_herbie/templates/view/views-view--taxonomy-term--tagged-news-items-block.html.twig
@@ -5,7 +5,8 @@
     'view-id-' ~ id,
     'view-display-id-' ~ display_id,
     dom_id ? 'js-view-dom-id-' ~ dom_id,
-    'dcf-mt-8'
+    'dcf-mt-8',
+    'dcf-mb-8'
   ]
 %}
 <div{{ attributes.addClass(classes).setAttribute('id', 'news-'~ dom_id) }}>
@@ -28,10 +29,16 @@
 
   {{ pager }}
   {{ attachment_after }}
-  {% if view.total_rows > 12 and more %}
+
+  {% if preprocessed_total_rows > 12 and more %}
     <div class="dcf-d-flex dcf-jc-flex-end">
       <a class="dcf-btn dcf-btn-secondary dcf-capitalize" href="{{more['#url'].toString}}news">More news</a>
     </div>
+  {% elseif preprocessed_total_rows > 12 %}
+    <div class="dcf-d-flex dcf-jc-flex-end">
+      <a class="dcf-btn dcf-btn-secondary dcf-capitalize" href="{{path('<current>')}}news">More news</a>
+    </div>
+
   {% endif %}
   {% if footer %}
     {{ footer }}

--- a/web/themes/custom/unl_six_herbie/unl_six_herbie.theme
+++ b/web/themes/custom/unl_six_herbie/unl_six_herbie.theme
@@ -512,6 +512,38 @@ function unl_six_herbie_preprocess_layout(&$variables) {
 }
 
 /**
+ * Implements template_preprocess_views_view.
+ */
+function unl_six_herbie_preprocess_views_view(&$variables) {
+  // Add preprocessed total rows to taxonomy_term view (tagged_news_items_block)
+  // since total rows only counts current page, not total tagged items.
+  if ($variables['view']->id() === 'taxonomy_term' && $variables['view']->current_display === 'tagged_news_items_block') {
+   try {
+      // Load a fresh instance of the view.
+      $full_view = Views::getView('taxonomy_term');
+      if (!$full_view) {
+        return;
+      }
+      // Set the display and remove pagination limit.
+      $full_view->setDisplay('tagged_news_items_block');
+      $full_view->setItemsPerPage(0);
+      // Pass any contextual arguments from the original view.
+      if (!empty($variables['view']->args)) {
+        $full_view->setArguments($variables['view']->args);
+      }
+      // Execute the view.
+      $full_view->preExecute();
+      $full_view->execute();
+      // Add results to template variables to be used in Twig.
+      $variables['preprocessed_total_rows'] = $full_view->total_rows ?: count($full_view->result);
+
+    } catch (\Exception $e) {
+      \Drupal::logger('unl_six_herbie_preprocess_views_view')->error('Error processing view: @message', ['@message' => $e->getMessage()]);
+    }
+  }
+}
+
+/**
  * Implements template_preprocess_views_view_fields().
  */
 function unl_six_herbie_preprocess_views_view_fields(&$variables) {


### PR DESCRIPTION
…nclude the full item/row count (only current page items). This new variable is used in Twig to determine whether the “more” link should appear. Fixes #1110.