### PR TITLE
Removed aspect ratio. Because of the grid setup, using a fixed aspect…

### DIFF
--- a/web/themes/custom/unl_six_herbie/css/theme/block/tandem.css
+++ b/web/themes/custom/unl_six_herbie/css/theme/block/tandem.css
@@ -241,11 +241,8 @@
   .unlcms-tandem-basic-img .media-entity-bundle--image,
   .unlcms-tandem-stack-img .media-entity-bundle--image {
     margin-bottom: 0;
-    bottom: 0 !important;
-    left: 0 !important;
-    position: absolute !important;
-    right: 0 !important;
-    top: 0 !important;
+    height: 100%;
+    width: 100%;
   }
 
   .unlcms-tandem-fade-img img,

--- a/web/themes/custom/unl_six_herbie/templates/block/block--block-content-tandem.html.twig
+++ b/web/themes/custom/unl_six_herbie/templates/block/block--block-content-tandem.html.twig
@@ -81,7 +81,7 @@
             {% endif %}
           </div>
         </div>
-        <div class="unlcms-tandem-stack-img dcf-relative dcf-16x9">
+        <div class="unlcms-tandem-stack-img dcf-relative">
           {{content.b_tandem_image}}
         </div>
       </div>
@@ -136,7 +136,7 @@
             </ul>
           {% endif %}
         </div>
-        <div class="unlcms-tandem-fade-img dcf-relative dcf-16x9 dcf-4x3@md dcf-4x3@lg dcf-16x9@xl">
+        <div class="unlcms-tandem-fade-img dcf-relative">
           {{content.b_tandem_image}}
         </div>
       </div>


### PR DESCRIPTION
… ratio does not work as intended. Even if an aspect ratio is applied, it will cause the image to overflow into the "fade" gray area, which would require reworking how the entire grid handles that. I made sure to check the other Tandem types too. Fixes #1150.