### PR TITLE
Added the dcf-txt-center class to the header class list to enable centering a section header. Fixes #1181.

### DIFF
--- a/web/modules/custom/dcf_layouts/src/Plugin/Layout/DcfLayoutBase.php
+++ b/web/modules/custom/dcf_layouts/src/Plugin/Layout/DcfLayoutBase.php
@@ -73,6 +73,7 @@ abstract class DcfLayoutBase extends LayoutDefault implements PluginFormInterfac
       'dcf-capitalize' => 'dcf-capitalize',
       'dcf-lowercase' => 'dcf-lowercase',
       'dcf-uppercase' => 'dcf-uppercase',
+      'dcf-txt-center' => 'dcf-txt-center',
     ];
 
     $form['title_classes'] = [


### PR DESCRIPTION
Closes #1181 