### PR TITLE
Added an ID to the div that wraps the component, derived from the block label, ID, and region block ID. Fixes #1191.

### DIFF
--- a/web/themes/custom/unl_six_herbie/unl_six_herbie.theme
+++ b/web/themes/custom/unl_six_herbie/unl_six_herbie.theme
@@ -94,7 +94,8 @@ function unl_six_herbie_preprocess_block(&$variables) {
           if (isset($variables['elements']['#configuration']['id'])) {
             $component_id_prefix = $variables['elements']['#configuration']['id'];
           }
-        } else {
+        }
+        else {
           $component_id_prefix = $variables['elements']['#configuration']['label'];
         }
         // Use the region block ID to ensure unique IDs for reused custom blocks in Layout Builder.


### PR DESCRIPTION
Closes #1191.